### PR TITLE
Access Policy Runner Story

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,7 +121,7 @@ they be run in a production environment.
 Set 2 environment variables and execute:
 
 ```bash
-export TEST_ARCHIVIST="https://app.rkvst.io"
+export TEST_ARCHIVIST="https://app.rkvst-dev.io"
 export TEST_AUTHTOKEN_FILENAME=credentials/authtoken
 task functests
 ```

--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -61,7 +61,6 @@ from .compliance_policies import _CompliancePoliciesClient
 from .composite import _CompositeClient
 from .events import _EventsRestricted
 from .locations import _LocationsClient
-from .runner import _Runner
 from .sboms import _SBOMSClient
 from .subjects import _SubjectsClient
 from .tenancies import _TenanciesClient
@@ -98,7 +97,6 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
         "composite": _CompositeClient,
         "events": _EventsRestricted,
         "locations": _LocationsClient,
-        "runner": _Runner,
         "sboms": _SBOMSClient,
         "subjects": _SubjectsClient,
         "tenancies": _TenanciesClient,
@@ -145,7 +143,6 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
         self.composite: _CompositeClient
         self.events: _EventsRestricted
         self.locations: _LocationsClient
-        self.runner: _Runner
         self.sboms: _SBOMSClient
         self.subjects: _SubjectsClient
         self.tenancies: _TenanciesClient

--- a/archivist/cmds/runner/main.py
+++ b/archivist/cmds/runner/main.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
-from ...parser import common_parser, endpoint
+from ...parser import basic_parser, debug_level
 
 from .run import run
 
@@ -12,16 +12,16 @@ LOGGER = getLogger(__name__)
 
 
 def main():
-    parser = common_parser("Executes the archivist runner from a yaml file")
+    parser = basic_parser("Executes the archivist runner from a yaml file")
 
     parser.add_argument(
         "yamlfile", help="the yaml file describing the operations to conduct"
     )
     args = parser.parse_args()
 
-    arch = endpoint(args)
+    debug_level(args)
 
-    run(arch, args)
+    run(args)
 
     parser.print_help(sys_stdout)
     sys_exit(1)

--- a/archivist/cmds/runner/run.py
+++ b/archivist/cmds/runner/run.py
@@ -10,13 +10,13 @@ from pyaml_env import parse_config
 from ... import about
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from ... import archivist
+from ...runner import Runner
 
 
 LOGGER = getLogger(__name__)
 
 
-def run(arch: archivist.Archivist, args):
+def run(args):
 
     LOGGER.info("Using version %s of rkvst-archivist", about.__version__)
     LOGGER.info("Namespace %s", args.namespace)
@@ -27,6 +27,6 @@ def run(arch: archivist.Archivist, args):
         environ["ARCHIVIST_NAMESPACE"] = args.namespace
 
     with open(args.yamlfile, "r", encoding="utf-8") as yml:
-        arch.runner(parse_config(data=yml))
+        Runner()(parse_config(data=yml))
 
     sys_exit(0)

--- a/archivist/cmds/template/main.py
+++ b/archivist/cmds/template/main.py
@@ -4,7 +4,7 @@ from logging import getLogger
 from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
-from ...parser import common_parser, endpoint
+from ...parser import basic_parser, debug_level
 
 from .run import run
 
@@ -12,7 +12,7 @@ LOGGER = getLogger(__name__)
 
 
 def main():
-    parser = common_parser("Executes the archivist runner from a template file")
+    parser = basic_parser("Executes the archivist runner from a template file")
 
     parser.add_argument(
         "values",
@@ -23,9 +23,9 @@ def main():
     )
     args = parser.parse_args()
 
-    arch = endpoint(args)
+    debug_level(args)
 
-    run(arch, args)
+    run(args)
 
     parser.print_help(sys_stdout)
     sys_exit(1)

--- a/archivist/cmds/template/run.py
+++ b/archivist/cmds/template/run.py
@@ -11,13 +11,13 @@ import yaml
 from ... import about
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from ... import archivist as type_helper  # pylint:disable=unused-import
+from ...runner import Runner
 
 
 LOGGER = getLogger(__name__)
 
 
-def run(arch: "type_helper.Archivist", args):
+def run(args):
 
     LOGGER.info("Using version %s of rkvst-archivist", about.__version__)
     LOGGER.info("Namespace %s", args.namespace)
@@ -37,7 +37,7 @@ def run(arch: "type_helper.Archivist", args):
 
     # environment is injected into the template
     with open(args.values, "r", encoding="utf-8") as fd:
-        arch.runner(
+        Runner()(
             yaml.load(
                 template.render(
                     yaml.load(

--- a/archivist/constants.py
+++ b/archivist/constants.py
@@ -19,6 +19,13 @@ HEADERS_REQUEST_TOTAL_COUNT = "X-Request-Total-Count"
 HEADERS_TOTAL_COUNT = "X-Total-Count"
 HEADERS_RETRY_AFTER = "Archivist-Rate-Limit-Reset"
 
+# These are now hardcoded and not user-selectable. Eventually they will be removed from
+# the backend API and removed from this package.
+ASSET_BEHAVIOURS = [
+    "Attachments",
+    "RecordEvidence",
+]
+
 CONFIRMATION_STATUS = "confirmation_status"
 CONFIRMATION_PENDING = "PENDING"
 CONFIRMATION_FAILED = "FAILED"

--- a/archivist/parser.py
+++ b/archivist/parser.py
@@ -82,6 +82,11 @@ def common_parser(description: str):
         default="https://app.rkvst.io",
         help="url of Archivist service",
     )
+    return parser
+
+
+def common_parser(description: str):
+    parser = basic_parser(description)
     parser.add_argument(
         "-p",
         "--proof-mechanism",
@@ -144,12 +149,17 @@ def common_parser(description: str):
     return parser
 
 
-def endpoint(args):
+def debug_level(args):
 
     if args.verbose:
         set_logger("DEBUG")
     else:
         set_logger("INFO")
+
+
+def endpoint(args):
+
+    debug_level(args)
 
     arch = None
     LOGGER.info("Initialising connection to RKVST...")

--- a/archivist/runner.py
+++ b/archivist/runner.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from functools import partialmethod
 from json import dumps as json_dumps
 from logging import getLogger
+from operator import attrgetter
 from time import sleep as time_sleep
 from types import GeneratorType
 from typing import Any, Callable, Optional, Tuple
@@ -16,13 +17,15 @@ from uuid import UUID
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 # pylint:disable=missing-function-docstring
 # pylint:disable=protected-access
-from . import archivist
+from .archivist import Archivist
+from .confirmer import MAX_TIME
 from .errors import ArchivistError, ArchivistInvalidOperationError
+from .parser import get_auth
 
 LOGGER = getLogger(__name__)
 
 
-NOUNS = ("asset", "location", "subject")
+NOUNS = ("archivist", "access_policy", "asset", "location", "subject", "subject_import")
 
 
 def tree():
@@ -45,69 +48,138 @@ class _ActionMap(dict):
     #  use_asset_label = "asset_id"   = keyword argument
     #  use_asset_label = "-asset_id"   = keyword argument in first argumemt that is
     #                                    a dictionary
-    # similarly for location and subjects labels
+    # similarly for access_policy, location and subject labels
     #
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Optional[Archivist]):
         super().__init__()
-        self._archivist = archivist_instance
+        self.archivist = archivist_instance
+
+        self["ARCHIVIST_CREATE"] = {
+            "action": "archivist_create",
+            "pos": ("url",),
+            "keywords": (
+                "auth_token",
+                "client_id",
+                "client_secret",
+                "max_time",
+                "verify",
+            ),
+            "set_archivist_label": True,
+        }
 
         # please keep in alphabetical order
-        self["ASSETS_ATTACHMENT_INFO"] = {
-            "action": self._archivist.attachments.info,
+        self["ACCESS_POLICIES_COUNT"] = {
+            "action": "archivist.access_policies.count",
+            "keywords": ("display_name",),
+            "use_archivist_label": "add_archivist",
+        }
+        self["ACCESS_POLICIES_CREATE"] = {
+            "action": "archivist.access_policies.create_from_data",
+            "delete": "archivist.access_policies.delete",
+            "set_access_policy_label": True,
+            "use_archivist_label": "add_archivist",
+            "use_subject_import_label": "add_arg_identity",
+        }
+        self["ACCESS_POLICIES_LIST"] = {
+            "action": "archivist.access_policies.list",
+            "keywords": ("display_name",),
+            "use_archivist_label": "add_archivist",
+        }
+        self["ACCESS_POLICIES_LIST_MATCHING_ASSETS"] = {
+            "action": "archivist.access_policies.list_matching_assets",
+            "use_archivist_label": "add_archivist",
+        }
+        self["ACCESS_POLICIES_LIST_MATCHING_ACCESS_POLICIES"] = {
+            "action": "archivist.access_policies.list_matching_access_policies",
             "use_asset_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
+        }
+        self["ACCESS_POLICIES_READ"] = {
+            "action": "archivist.access_policies.read",
+            "use_access_policy_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
+        }
+        self["ACCESS_POLICIES_UPDATE"] = {
+            "action": "archivist.access_policies.update",
+            "keywords": (
+                "display_name",
+                "filters",
+                "access_permissions",
+            ),
+            "use_access_policy_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
+        }
+        self["ASSETS_ATTACHMENT_INFO"] = {
+            "action": "archivist.attachments.info",
+            "use_asset_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
         }
         self["ASSETS_COUNT"] = {
-            "action": self._archivist.assets.count,
+            "action": "archivist.assets.count",
             "keywords": (
                 "props",
                 "attrs",
             ),
+            "use_archivist_label": "add_archivist",
         }
         self["ASSETS_CREATE_IF_NOT_EXISTS"] = {
-            "action": self._archivist.assets.create_if_not_exists,
+            "action": "archivist.assets.create_if_not_exists",
             "keywords": ("confirm",),
             "set_asset_label": True,
             "use_location_label": "add_data_location_identity",
+            "use_archivist_label": "add_archivist",
         }
         self["ASSETS_CREATE"] = {
-            "action": self._archivist.assets.create_from_data,
+            "action": "archivist.assets.create_from_data",
             "keywords": ("confirm",),
             "set_asset_label": True,
+            "use_archivist_label": "add_archivist",
         }
         self["ASSETS_LIST"] = {
-            "action": self._archivist.assets.list,
+            "action": "archivist.assets.list",
             "keywords": (
                 "props",
                 "attrs",
             ),
+            "use_archivist_label": "add_archivist",
+        }
+        self["ASSETS_READ"] = {
+            "action": "archivist.assets.read",
+            "use_asset_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
         }
         self["ASSETS_WAIT_FOR_CONFIRMED"] = {
-            "action": self._archivist.assets.wait_for_confirmed,
+            "action": "archivist.assets.wait_for_confirmed",
             "keywords": (
                 "props",
                 "attrs",
             ),
+            "use_archivist_label": "add_archivist",
         }
         self["COMPOSITE_ESTATE_INFO"] = {
-            "action": self._archivist.composite.estate_info,
+            "action": "archivist.composite.estate_info",
+            "use_archivist_label": "add_archivist",
         }
         self["COMPLIANCE_POLICIES_CREATE"] = {
-            "action": self._archivist.compliance_policies.create_from_data,
-            "delete": self._archivist.compliance_policies.delete,
+            "action": "archivist.compliance_policies.create_from_data",
+            "delete": "archivist.compliance_policies.delete",
+            "use_archivist_label": "add_archivist",
         }
         self["COMPLIANCE_COMPLIANT_AT"] = {
-            "action": self._archivist.compliance.compliant_at,
+            "action": "archivist.compliance.compliant_at",
             "keywords": ("report",),
             "use_asset_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
         }
         self["EVENTS_CREATE"] = {
-            "action": self._archivist.events.create_from_data,
+            "action": "archivist.events.create_from_data",
             "keywords": ("confirm",),
             "use_asset_label": "add_arg_identity",
             "use_location_label": "add_data_location_identity",
+            "use_archivist_label": "add_archivist",
         }
         self["EVENTS_COUNT"] = {
-            "action": self._archivist.events.count,
+            "action": "archivist.events.count",
             "keywords": (
                 "asset_id",
                 "props",
@@ -115,9 +187,10 @@ class _ActionMap(dict):
                 "asset_attrs",
             ),
             "use_asset_label": "add_kwarg_asset_identity",
+            "use_archivist_label": "add_archivist",
         }
         self["EVENTS_LIST"] = {
-            "action": self._archivist.events.list,
+            "action": "archivist.events.list",
             "keywords": (
                 "asset_id",
                 "props",
@@ -125,69 +198,112 @@ class _ActionMap(dict):
                 "asset_attrs",
             ),
             "use_asset_label": "add_kwarg_asset_identity",
+            "use_archivist_label": "add_archivist",
         }
         self["LOCATIONS_COUNT"] = {
-            "action": self._archivist.locations.count,
+            "action": "archivist.locations.count",
             "keywords": (
                 "props",
                 "attrs",
             ),
+            "use_archivist_label": "add_archivist",
         }
         self["LOCATIONS_CREATE_IF_NOT_EXISTS"] = {
-            "action": self._archivist.locations.create_if_not_exists,
+            "action": "archivist.locations.create_if_not_exists",
             "keywords": ("confirm",),
             "set_location_label": True,
+            "use_archivist_label": "add_archivist",
         }
         self["LOCATIONS_LIST"] = {
-            "action": self._archivist.locations.list,
+            "action": "archivist.locations.list",
             "keywords": (
                 "props",
                 "attrs",
             ),
+            "use_archivist_label": "add_archivist",
         }
         self["LOCATIONS_READ"] = {
-            "action": self._archivist.locations.read,
+            "action": "archivist.locations.read",
             "use_location_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
         }
         self["SUBJECTS_COUNT"] = {
-            "action": self._archivist.subjects.count,
+            "action": "archivist.subjects.count",
             "keywords": ("display_name",),
+            "use_archivist_label": "add_archivist",
         }
         self["SUBJECTS_CREATE"] = {
-            "action": self._archivist.subjects.create_from_data,
-            "delete": self._archivist.subjects.delete,
+            "action": "archivist.subjects.create_from_data",
+            "delete": "archivist.subjects.delete",
             "set_subject_label": True,
+            "use_archivist_label": "add_archivist",
         }
         self["SUBJECTS_CREATE_FROM_B64"] = {
-            "action": self._archivist.subjects.create_from_b64,
-            "delete": self._archivist.subjects.delete,
+            "action": "archivist.subjects.create_from_b64",
+            "delete": "archivist.subjects.delete",
             "set_subject_label": True,
+            "use_archivist_label": "add_archivist",
         }
         self["SUBJECTS_DELETE"] = {
-            "action": self._archivist.subjects.delete,
+            "action": "archivist.subjects.delete",
             "use_subject_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
+        }
+        self["SUBJECTS_IMPORT"] = {
+            "action": "archivist.subjects.import_subject",
+            "pos": ("name",),
+            "use_subject_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
+            "set_subject_import_label": True,
         }
         self["SUBJECTS_LIST"] = {
-            "action": self._archivist.subjects.list,
+            "action": "archivist.subjects.list",
             "keywords": ("display_name",),
+            "use_archivist_label": "add_archivist",
         }
         self["SUBJECTS_READ"] = {
-            "action": self._archivist.subjects.read,
+            "action": "archivist.subjects.read",
             "use_subject_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
+        }
+        self["SUBJECTS_SHARE"] = {
+            "action": "archivist.subjects.share",
+            "pos": ("name","other_name", "other_archivist",),
+            "set_subjects_label": True,
+            "use_archivist_label": "add_archivist",
         }
         self["SUBJECTS_UPDATE"] = {
-            "action": self._archivist.subjects.update,
+            "action": "archivist.subjects.update",
             "keywords": (
                 "display_name",
                 "wallet_pub_key",
                 "tessera_pub_key",
             ),
             "use_subject_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
         }
         self["SUBJECTS_WAIT_FOR_CONFIRMATION"] = {
-            "action": self._archivist.subjects.wait_for_confirmation,
+            "action": "archivist.subjects.wait_for_confirmation",
             "use_subject_label": "add_arg_identity",
+            "use_archivist_label": "add_archivist",
         }
+
+    @staticmethod
+    def archivist_create(
+        url: str,
+        *,
+        auth_token: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        max_time: float = MAX_TIME,
+        verify: bool = True,
+    ) -> Archivist:
+        auth = get_auth(
+            auth_token=auth_token,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        return Archivist(url, auth, max_time=max_time, verify=verify)
 
     def ops(self, action_name: str) -> dict[str, Any]:
         """
@@ -203,7 +319,8 @@ class _ActionMap(dict):
         Get valid action in map
         """
         # if an exception occurs here then the dict initialised above is faulty.
-        return self.ops(action_name).get("action")  # type: ignore
+        action = self.ops(action_name).get("action")
+        return attrgetter(action)(self)  # type: ignore
 
     def keywords(self, action_name: str) -> Tuple | None:
         """
@@ -211,11 +328,21 @@ class _ActionMap(dict):
         """
         return self.ops(action_name).get("keywords")
 
-    def delete(self, action_name: str):
+    def pos(self, action_name: str) -> Tuple | None:
+        """
+        Get positional args in map
+        """
+        return self.ops(action_name).get("pos")
+
+    def delete(self, action_name: str) -> Optional[Callable]:
         """
         Get delete_method in map
         """
-        return self.ops(action_name).get("delete")
+        delete = self.ops(action_name).get("delete")
+        if delete is None:
+            return None
+
+        return attrgetter(delete)(self)  # type: ignore
 
     def label(self, noun: str, endpoint: str, action_name: str) -> bool:
         """
@@ -225,9 +352,9 @@ class _ActionMap(dict):
 
 
 class _Step(dict):  # pylint:disable=too-many-instance-attributes
-    def __init__(self, archivist_instance: archivist.Archivist, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._archivist = archivist_instance
+        self._archivist = None
         self._args: list[Any] = []
         self._kwargs: dict[str, Any] = {}
         self._actions = None
@@ -235,31 +362,66 @@ class _Step(dict):  # pylint:disable=too-many-instance-attributes
         self._action_name = None
         self._data = {}
         self._keywords = None
+        self._pos = None
         self._delete_method = None
         self._labels = {}
         self._labels["use"] = {}
         self._labels["set"] = {}
 
-    def add_arg_identity(self, identity):
+    def add_arg_identity(self, noun, entities):
+        """Gets the identity of an entity previously created from its label
+        and insert into the current positional argument
+        (usually the first positional argument
+        """
+        identity = self.identity_from_label(noun, entities)
         self._args.append(identity)
 
-    def add_kwarg_identity(self, key, identity):
+    def add_archivist(self, noun, entities):
+        """sets the current archivist object to one previously defined"""
+        label = self.get(f"{noun}_label")
+        self._archivist = entities[label]
+
+    def add_kwarg_identity(self, key, noun, entities):
+        """Gets the identity of an entity previously created from its label
+        and insert into a keyword argument.
+
+        This is used as a partial method for asset_id,location etc...
+        """
+        identity = self.identity_from_label(noun, entities)
         self._kwargs[key] = identity
 
     add_kwarg_asset_identity = partialmethod(add_kwarg_identity, "asset_id")
 
-    def add_data_identity(self, key, identity):
+    def add_data_identity(self, key, noun, entities):
+        """Gets the identity of an entity previously created from its label
+        and insert into a data object.
+
+        This is used as a partial method for location etc...
+        """
+        identity = self.identity_from_label(noun, entities)
         self._data[key] = {}
         self._data[key]["identity"] = identity
 
     add_data_location_identity = partialmethod(add_data_identity, "location")
 
-    def args(self, identity_method, step):
+    def args(self, entities, step):
         """
         Add args and kwargs to action.
         """
         self._args = []
         self._kwargs = {}
+
+        for noun in NOUNS:
+            label = self.get(f"{noun}_label")
+            func = self.label("use", noun)
+            if label is not None and func:
+                getattr(self, func)(noun, entities)
+
+        self.actions.archivist = (
+            self._archivist
+            if self.actions.archivist is None
+            else self.actions.archivist
+        )
 
         # keys are values that must be removed from the body of the request.
         # These are typically 'confirm' or 'report'. Some of the actions
@@ -273,22 +435,17 @@ class _Step(dict):  # pylint:disable=too-many-instance-attributes
                 if k in step:
                     self._kwargs[k] = step[k]
 
+        if self.pos:
+            self._args = [step[pos] for pos in self.pos]
+            keys.extend(self.pos)
+
         # add the request body to the positional arguments...
         self._data = {k: v for k, v in step.items() if k not in keys}
 
-        for noun in NOUNS:
-            label = self.get(f"{noun}_label")
-            func = self.label("use", noun)
-            if label is not None and func:
-
-                identity = self.identity_from_label(noun, identity_method)
-                if identity is None:
-                    raise ArchivistInvalidOperationError(f"unknown {noun} '{label}'")
-
-                getattr(self, func)(identity)
-
         if self._data:
             self._args.append(self._data)
+
+        LOGGER.debug("pos args %s", self._args)
 
     def execute(self):
         action = self.action
@@ -312,29 +469,39 @@ class _Step(dict):  # pylint:disable=too-many-instance-attributes
 
         return self._labels[verb][noun]
 
-    def identity_from_label(self, noun, identity_method):
+    def identity_from_label(self, noun, entities):
         label = self.get(f"{noun}_label")
-        if not label.startswith(f"{noun}s/"):  # type: ignore
-            return identity_method(label)
 
+        # If it is a label, get the identity from previously created entity
+        if not label.startswith(f"{noun}s/"):  # type: ignore
+            identity = entities[label]["identity"]
+            if isinstance(identity, str):
+                return identity
+
+            raise ArchivistInvalidOperationError(f"unknown {noun}")
+
+        # else treat the value as an actual identity of the form {noun}s/{uuid}
         uid = label.split("/")[1]  # type: ignore
         try:
             _ = UUID(uid, version=4)
-        except ValueError:
-            return None
+        except ValueError as exc:
+            raise ArchivistInvalidOperationError(f"invalid {noun}s/{uid}") from exc
 
         return label
 
     def description(self):
+        """emit description field if required"""
         description = self.get("description")
         if description is not None:
             LOGGER.info(description)
 
     @property
     def delete(self):
+        """action might have a delete method"""
         return self.get("delete")
 
     def print_response(self, response):
+        """print json response if required"""
         print_response = self.get("print_response")
         if print_response:
             # some responses are generators...
@@ -345,6 +512,7 @@ class _Step(dict):  # pylint:disable=too-many-instance-attributes
                 LOGGER.info("Response %s", json_dumps(response, indent=4))
 
     def wait_time(self):
+        """wait if required"""
         wait_time = self.get("wait_time", 0)
         if wait_time > 0:
             LOGGER.info("Waiting for %d seconds", wait_time)
@@ -365,7 +533,7 @@ class _Step(dict):  # pylint:disable=too-many-instance-attributes
         return self._action
 
     @property
-    def delete_method(self):
+    def delete_method(self) -> Optional[Callable]:
         if self._delete_method is None:
             self._delete_method = self.actions.delete(self.action_name)
 
@@ -379,6 +547,13 @@ class _Step(dict):  # pylint:disable=too-many-instance-attributes
         return self._keywords
 
     @property
+    def pos(self):
+        if self._pos is None:
+            self._pos = self.actions.pos(self.action_name)
+
+        return self._pos
+
+    @property
     def action_name(self):
         if self._action_name is None:
             action_name = self.get("action")
@@ -390,18 +565,17 @@ class _Step(dict):  # pylint:disable=too-many-instance-attributes
         return self._action_name
 
 
-class _Runner:
+class Runner:
     """
     ArchivistRunner takes a url, token_file.
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
-        self._archivist = archivist_instance
-        self.entities: defaultdict
+    def __init__(self):
+        self.entities = tree()
         self.deletions = {}
 
     def __str__(self) -> str:
-        return f"Runner({self._archivist.url})"
+        return "Runner()"
 
     def __call__(self, config: dict[str, Any]):
         """
@@ -414,6 +588,7 @@ class _Runner:
                     "action": "ASSETS_CREATE",
                     "description": "Create a Radiation bag number one",
                     "wait_time": 10,
+                    "archivist_label": "ACME Corporation",
                 },
                 "attributes": {
                     "arc_display_name": "radiation bag 1",
@@ -441,12 +616,10 @@ class _Runner:
 
     def run_steps(self, config: dict[str, Any]):
         """Runs all defined steps in self.config."""
-        self.entities = tree()
         for step in config["steps"]:
             self.run_step(step)
 
         self.delete()
-        self._archivist.close()
 
     def run_step(self, step: dict[str, Any]):
         """Runs a step given parameters and the type of step.
@@ -456,13 +629,11 @@ class _Runner:
         """
 
         # get step settings
-        s = _Step(self._archivist, **step.pop("step"))
+        s = _Step(**step.pop("step"))
 
         # output description
         s.description()
-
-        # this is a bit clunky...
-        s.args(self.identity, step)
+        s.args(self.entities, step)
 
         # wait for a number of seconds and then execute
         s.wait_time()
@@ -490,12 +661,3 @@ class _Runner:
         for identity, delete_method in self.deletions.items():
             LOGGER.info("Delete %s", identity)
             delete_method(identity)
-
-    def identity(self, name: str) -> Optional[str]:
-        """Gets entity id"""
-
-        identity = self.entities[name]["identity"]
-        if isinstance(identity, str):
-            return identity
-
-        return None

--- a/docs/runner/components/access_policies_count.rst
+++ b/docs/runner/components/access_policies_count.rst
@@ -1,9 +1,11 @@
-.. _subjects_count_yamlref:
+.. _access_policies_count_yamlref:
 
-Subjects Count Story Runner YAML
+Access Policies Count Story Runner YAML
 .........................................
 
-Count all subjects that have the required signature.
+Count all access_policies that have the required signature.
+
+The :code:`archivist_label` is required.
 
 The :code:`display_name` is optional.
 
@@ -14,8 +16,8 @@ The :code:`print_response` setting should be specified as :code:`True` in order 
     ---
     steps:
       - step:
-          action: SUBJECTS_COUNT
-          description: Count all subjects
+          action: ACCESS_POLICIES_COUNT
+          description: Count all access_policies
           print_response: true
           archivist_label: Acme Corporation
-        display_name: some subject
+        display_name: some access_policy

--- a/docs/runner/components/access_policies_create.rst
+++ b/docs/runner/components/access_policies_create.rst
@@ -1,0 +1,22 @@
+.. _access_policies_create_yamlref:
+
+Access Policies Create Story Runner YAML
+.........................................
+
+:code:`access_policy_label` is not required but if unspecified the created access policy  will
+not be accessible to later actions in the story.
+
+.. code-block:: yaml
+    
+    ---
+    steps:
+      - step:
+          action: ACCESS_POLICIES_CREATE
+          description: Create an access_policy entity.
+          print_response: true
+          archivist_label: Acme Corporation
+          access_policy_label: An access policy
+        display_name: An access policy
+        description: An access policy
+        filters:
+        access_permissions:

--- a/docs/runner/components/access_policies_list.rst
+++ b/docs/runner/components/access_policies_list.rst
@@ -1,9 +1,9 @@
-.. _subjects_list_yamlref:
+.. _access_policies_list_yamlref:
 
-Subjects List Story Runner YAML
+Access Policies List Story Runner YAML
 .........................................
 
-List all subjects that have the required signature.
+List all access_policies that have the required signature.
 
 The :code:`print_response` setting should be specified as :code:`True` in order to see the results.
 
@@ -12,8 +12,8 @@ The :code:`print_response` setting should be specified as :code:`True` in order 
     ---
     steps:
       - step:
-          action: SUBJECTS_LIST
-          description: List all subjects
+          action: ACCESS_POLICIES_LIST
+          description: List all access_policies
           print_response: true
           archivist_label: Acme Corporation
-        display_name: some subject
+        display_name: some access policy

--- a/docs/runner/components/access_policies_list_matching_access_policies.rst
+++ b/docs/runner/components/access_policies_list_matching_access_policies.rst
@@ -1,0 +1,19 @@
+.. _access_policies_list_matching_access_policiesyamlref:
+
+Access Policies List Matching AccessPolicies Story Runner YAML
+...............................................................
+
+List all access policies that match an asset.
+
+The :code:`print_response` setting should be specified as :code:`True` in order to see the results.
+
+.. code-block:: yaml
+    
+    ---
+    steps:
+      - step:
+          action: ACCESS_POLICIES_LIST_MATCHING_ACCESS_POLICIES
+          description: List all access policies that match an asset
+          print_response: true
+          archivist_label: Acme Corporation
+          asset_label: an asset

--- a/docs/runner/components/access_policies_list_matching_assets.rst
+++ b/docs/runner/components/access_policies_list_matching_assets.rst
@@ -1,0 +1,19 @@
+.. _access_policies_list_matching_assetsyamlref:
+
+Access Policies List Matching Assets Story Runner YAML
+.......................................................
+
+List all assets that match an access_policy.
+
+The :code:`print_response` setting should be specified as :code:`True` in order to see the results.
+
+.. code-block:: yaml
+    
+    ---
+    steps:
+      - step:
+          action: ACCESS_POLICIES_LIST_MATCHING_ASSETS
+          description: List assets that match an access_policy
+          print_response: true
+          archivist_label: Acme Corporation
+          access_policy_label: an access policy

--- a/docs/runner/components/access_policies_read.rst
+++ b/docs/runner/components/access_policies_read.rst
@@ -1,9 +1,11 @@
-.. _subjects_list_yamlref:
+.. _access_policies_read_yamlref:
 
-Subjects List Story Runner YAML
+Access Policies Read Story Runner YAML
 .........................................
 
-List all subjects that have the required signature.
+Read the specified access_policy.
+
+:code:`access_policy_label` is required.
 
 The :code:`print_response` setting should be specified as :code:`True` in order to see the results.
 
@@ -12,8 +14,8 @@ The :code:`print_response` setting should be specified as :code:`True` in order 
     ---
     steps:
       - step:
-          action: SUBJECTS_LIST
-          description: List all subjects
+          action: ACCESS_POLICIES_READ
+          description: Read access_policy
           print_response: true
           archivist_label: Acme Corporation
-        display_name: some subject
+          access_policy_label: An access policy

--- a/docs/runner/components/access_policies_update.rst
+++ b/docs/runner/components/access_policies_update.rst
@@ -1,0 +1,23 @@
+.. _access_policies_update_yamlref:
+
+Access Policies Update Story Runner YAML
+.........................................
+
+:code:`access_policy_label` is required.
+
+:code:`display_name`, :code:`filters` and :code:`access_permissions` are 
+optional but at least one must be specified.
+
+.. code-block:: yaml
+    
+    ---
+    steps:
+      - step:
+          action: ACCESS_POLICIES_UPDATE
+          description: Update a access_policies entity.
+          print_response: true
+          archivist_label: Acme Corporation
+          subject_label: An access policy
+        display_name: An access policy
+        filters:
+        access_permissions:

--- a/docs/runner/components/archivist_create.rst
+++ b/docs/runner/components/archivist_create.rst
@@ -1,0 +1,53 @@
+.. _archivist_create_yamlref:
+
+Archivist Create Story Runner YAML
+.......................................
+
+This action must be defined as the first action in any runner story. There can be more than one
+for different tenants. (typically when sharing assets between tenants...)
+
+:code:`archivist_label` is required and is used to access the endpoint for all other actions.
+
+:code:`url` is required.
+
+Usually these field values are derived from an environment variable 
+:code:`ARCHIVIST_NAMESPACE` (default value is :code:`namespace`).
+
+If optional :code:`auth_token` is defined then :code:`client_id` and :code:`client_secret` are not required.
+
+Conversely if :code:`auth_token` is not defined then both :code:`client_id` and :code:`client_secret` must
+be specified.
+
+The code:`max_time` and :code:`verify` are optional. If unspecified suitable defaults are used.
+
+
+With auth_token:
+
+.. code-block:: yaml
+    
+    ---
+    steps:
+      - step:
+          action: ARCHIVIST_CREATE
+          description: Archivist interface for Acme Corporation
+          archivist_label: Acme Corporation
+        url: https://app.rkvst.io
+        auth_token: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        max_time: 30
+        verify: True
+
+
+With app registration id and secret and default max_time/verify
+
+.. code-block:: yaml
+    
+    ---
+    steps:
+      - step:
+          action: ARCHIVIST_CREATE
+          description: Archivist interface for Acme Corporation
+          archivist_label: Acme Corporation
+        url: https://app.rkvst.io
+        client_id: xxxxxxxxxxxxxxxxxxx
+        client_secret: yyyyyyyyyyyyyyyyyyyyyyy
+

--- a/docs/runner/components/assets_count.rst
+++ b/docs/runner/components/assets_count.rst
@@ -16,5 +16,6 @@ Setting :code:`print_response: true` is necessary to print the full result.
           action: ASSETS_COUNT
           description: Count all doors
           print_response: true
+          archivist_label: Acme Corporation
         attrs:
           arc_display_type: door

--- a/docs/runner/components/assets_create.rst
+++ b/docs/runner/components/assets_create.rst
@@ -23,6 +23,7 @@ The optional :code:`confirm: true` entry means that the step will wait for the a
       - step:
           action: ASSETS_CREATE
           description: Create new EV Pump with id 1.
+          archivist_label: Acme Corporation
           asset_label: ev pump 1
         behaviours:
           - Attachments

--- a/docs/runner/components/assets_list.rst
+++ b/docs/runner/components/assets_list.rst
@@ -16,6 +16,7 @@ Setting :code:`print_response: true` is necessary to print the full result.
           action: ASSETS_LIST
           description: List all doors
           print_response: true
+          archivist_label: Acme Corporation
         attrs:
           arc_display_type: door
           arc_namespace: door entry

--- a/docs/runner/components/assets_read.rst
+++ b/docs/runner/components/assets_read.rst
@@ -1,9 +1,11 @@
-.. _subjects_list_yamlref:
+.. _assets_read_yamlref:
 
-Subjects List Story Runner YAML
+Assets Read Story Runner YAML
 .........................................
 
-List all subjects that have the required signature.
+Read the specified subject.
+
+:code:`asset_label` is required.
 
 The :code:`print_response` setting should be specified as :code:`True` in order to see the results.
 
@@ -12,8 +14,8 @@ The :code:`print_response` setting should be specified as :code:`True` in order 
     ---
     steps:
       - step:
-          action: SUBJECTS_LIST
-          description: List all subjects
+          action: LOCATIONS_READ
+          description: Read asset
           print_response: true
           archivist_label: Acme Corporation
-        display_name: some subject
+          asset_label: An asset

--- a/docs/runner/components/assets_wait_for_confirmed.rst
+++ b/docs/runner/components/assets_wait_for_confirmed.rst
@@ -12,5 +12,6 @@ Wait for all assets that have the required signature to be confirmed.
       - step:
           action: ASSETS_WAIT_FOR_CONFIRMED
           description: Wait for all assets to be confirmed
+          archivist_label: Acme Corporation
         attrs:
           arc_namespace: synsation

--- a/docs/runner/components/compliance_compliant_at.rst
+++ b/docs/runner/components/compliance_compliant_at.rst
@@ -18,4 +18,5 @@ Setting :code:`report: true` will trigger a report to be printed on the complian
           action: COMPLIANCE_COMPLIANT_AT
           description: Check Compliance of EV pump 1.
           report: true
+          archivist_label: Acme Corporation
           asset_label: ev pump 1

--- a/docs/runner/components/compliance_policies_create.rst
+++ b/docs/runner/components/compliance_policies_create.rst
@@ -16,6 +16,7 @@ This example is for a :code:`DYNAMIC_TOLERANCE` type policy.
           action: COMPLIANCE_POLICIES_CREATE
           description: Create a compliance policy that checks an EV pump maintenance requests are serviced within a reasonable time frame.
           print_response: true
+          archivist_label: Acme Corporation
         description: ev maintenance policy
         display_name: ev maintenance policy
         compliance_type: COMPLIANCE_DYNAMIC_TOLERANCE
@@ -37,6 +38,7 @@ This example is for a :code:`RICHNESS` type policy.
           action: COMPLIANCE_POLICIES_CREATE
           description: Create a compliance policy that checks the radiation level of radiation bags is less than 7 rads.
           print_response: true
+          archivist_label: Acme Corporation
         description: radiation level safety policy
         display_name: radiation safety policy
         compliance_type: COMPLIANCE_RICHNESS

--- a/docs/runner/components/composite_estate_info.rst
+++ b/docs/runner/components/composite_estate_info.rst
@@ -12,3 +12,4 @@ Output report on current number of assets, events and locations.
       - step:
           action: COMPOSITE_ESTATE_INFO
           description: Estate Info Report
+          archivist_label: Acme Corporation

--- a/docs/runner/components/events_count.rst
+++ b/docs/runner/components/events_count.rst
@@ -19,6 +19,7 @@ This example counts all 'open door' events for the Courts of Justice Front Door.
           action: EVENTS_COUNT
           description: List all events for Courts of Justice Paris Front Door
           print_response: true
+          archivist_label: Acme Corporation
           asset_label: Courts of Justice Paris Front Door
         props:
           confirmation_status: CONFIRMED

--- a/docs/runner/components/events_create.rst
+++ b/docs/runner/components/events_create.rst
@@ -28,6 +28,7 @@ An example when opening a door in Paris:
           description: Access Card 2 opens Courts of justice front door
           asset_label: Access Card 2
           print_response: true
+          archivist_label: Acme Corporation
         operation: Record
         behaviour: RecordEvidence
         principal_declared:
@@ -71,6 +72,7 @@ An example when releasing a software package as an sbom:
           description: Release YYYYMMDD.1 of Test SBOM for YAML story
           asset_label: ACME Corporation Detector SAAS
           print_response: true
+          archivist_label: Acme Corporation
         operation: Record
         behaviour: RecordEvidence
         confirm: true
@@ -97,6 +99,7 @@ An example when releasing a software package as an sbom attachment:
           description: Release YYYYMMDD.1 of Test SBOM for YAML story
           asset_label: ACME Corporation Detector SAAS
           print_response: true
+          archivist_label: Acme Corporation
         operation: Record
         behaviour: RecordEvidence
         confirm: true

--- a/docs/runner/components/events_list.rst
+++ b/docs/runner/components/events_list.rst
@@ -21,6 +21,7 @@ This example lists all 'open door' events for the Courts of Justice Front Door.
           action: EVENTS_LIST
           description: List all events for Courts of Justice Paris Front Door
           print_response: true
+          archivist_label: Acme Corporation
           asset_label: Courts of Justice Paris Front Door
         props:
           confirmation_status: CONFIRMED

--- a/docs/runner/components/generic.rst
+++ b/docs/runner/components/generic.rst
@@ -17,6 +17,7 @@ Each step follows the same pattern:
           description: Create new EV Pump with id 1.
           wait_time: 10
           print_response: true
+          archivist_label: ACME Corporation
           asset_label: Radiation bag 1
           location_label: Cape Town
         ................definition of request body and other
@@ -39,6 +40,11 @@ Each step follows the same pattern:
 
 :print_response:
    Emit JSON representation of response. Useful for debugging purposes.
+
+:archivist_label:
+   This references a previously created archivist endpoint. This field is required.
+
+   See the ARCHIVIST_CREATE action.
 
 :asset_label:
    For create type actions (ASSETS_CREATE, ASSETS_CREATE_IF_NOT_EXISTS) the label is used

--- a/docs/runner/components/index.rst
+++ b/docs/runner/components/index.rst
@@ -8,10 +8,21 @@ Story Runner Components
    :caption: Contents:
 
    generic
+
+   archivist_create
+
+   access_policies_count
+   access_policies_create
+   access_policies_list
+   access_policies_list_matching_access_policies
+   access_policies_list_matching_assets
+   access_policies_read
+   access_policies_update
    assets_count
    assets_create
    assets_create_if_not_exists
    assets_list
+   assets_read
    assets_wait_for_confirmed
    compliance_compliant_at
    compliance_policies_create
@@ -22,6 +33,7 @@ Story Runner Components
    locations_count
    locations_create
    locations_list
+   locations_read
    subjects_count
    subjects_create
    subjects_create_b64

--- a/docs/runner/components/locations_count.rst
+++ b/docs/runner/components/locations_count.rst
@@ -15,5 +15,6 @@ Setting :code:`print_response: true` is necessary to print the full result.
           action: LOCATIONS_COUNT
           description: Count location for which John Smith is director
           print_response: true
+          archivist_label: Acme Corporation
         attrs:
           director: John Smith

--- a/docs/runner/components/locations_create.rst
+++ b/docs/runner/components/locations_create.rst
@@ -12,6 +12,7 @@ Creates a location and stores a reference in runner variable :code:`location_lab
       - step:
           action: LOCATIONS_CREATE_IF_NOT_EXISTS
           description: Create Cape Town Location
+          archivist_label: Acme Corporation
         selector:
           - display_name
           - attributes:

--- a/docs/runner/components/locations_list.rst
+++ b/docs/runner/components/locations_list.rst
@@ -15,5 +15,6 @@ Setting :code:`print_response: true` is necessary to print the full result.
           action: LOCATIONS_LIST
           description: List locations for which John Smith is director
           print_response: true
+          archivist_label: Acme Corporation
         attrs:
           director: John Smith

--- a/docs/runner/components/locations_read.rst
+++ b/docs/runner/components/locations_read.rst
@@ -1,9 +1,11 @@
-.. _subjects_list_yamlref:
+.. _locations_read_yamlref:
 
-Subjects List Story Runner YAML
+Locations Read Story Runner YAML
 .........................................
 
-List all subjects that have the required signature.
+Read the specified subject.
+
+:code:`location_label` is required.
 
 The :code:`print_response` setting should be specified as :code:`True` in order to see the results.
 
@@ -12,8 +14,8 @@ The :code:`print_response` setting should be specified as :code:`True` in order 
     ---
     steps:
       - step:
-          action: SUBJECTS_LIST
-          description: List all subjects
+          action: LOCATIONS_READ
+          description: Read location
           print_response: true
           archivist_label: Acme Corporation
-        display_name: some subject
+          location_label: A subject

--- a/docs/runner/components/subjects_create.rst
+++ b/docs/runner/components/subjects_create.rst
@@ -14,6 +14,7 @@ not be accessible to later actions in the story.
           action: SUBJECTS_CREATE
           description: Create a subjects entity.
           print_response: true
+          archivist_label: Acme Corporation
           subject_label: A subject
         display_name: A subject
         wallet_pub_key:

--- a/docs/runner/components/subjects_create_b64.rst
+++ b/docs/runner/components/subjects_create_b64.rst
@@ -14,6 +14,7 @@ not be accessible to later actions in the story.
           action: SUBJECTS_CREATE_FROM_B64
           description: Import a subjects entity.
           print_response: true
+          archivist_label: Acme Corporation
           subject_label: An imported subject
         display_name: An imported subject
         subject_string: >-

--- a/docs/runner/components/subjects_delete.rst
+++ b/docs/runner/components/subjects_delete.rst
@@ -17,4 +17,5 @@ The :code:`print_response` setting should be specified as :code:`True` in order 
           action: SUBJECTS_DELETE
           description: Dele subject
           print_response: true
+          archivist_label: Acme Corporation
           subject_label: A subject

--- a/docs/runner/components/subjects_read.rst
+++ b/docs/runner/components/subjects_read.rst
@@ -17,4 +17,5 @@ The :code:`print_response` setting should be specified as :code:`True` in order 
           action: SUBJECTS_READ
           description: Read subject
           print_response: true
+          archivist_label: Acme Corporation
           subject_label: A subject

--- a/docs/runner/components/subjects_update.rst
+++ b/docs/runner/components/subjects_update.rst
@@ -16,6 +16,7 @@ optional but at least one must be specified.
           action: SUBJECTS_UPDATE
           description: Update a subjects entity.
           print_response: true
+          archivist_label: Acme Corporation
           subject_label: A subject
         display_name: A subject
         wallet_pub_key:

--- a/docs/runner/components/subjects_wait_for_confirmation.rst
+++ b/docs/runner/components/subjects_wait_for_confirmation.rst
@@ -15,4 +15,5 @@ Wait for a subject to be confirmed.
           action: SUBJECTS_WAIT_FOR_CONFIRMATION
           description: Wait for all subjects to be confirmed
           print_response: true
+          archivist_label: Acme Corporation
           subject_label: A subject

--- a/functests/test_resources/access_policies_story.yaml
+++ b/functests/test_resources/access_policies_story.yaml
@@ -1,0 +1,118 @@
+---
+steps:
+  # ACME corporation - create one asset
+  - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection for ACME corporation
+      archivist_label: ACME Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN}
+    client_id: !ENV ${TEST_CLIENT_ID}
+    client_secret: !ENV ${TEST_CLIENT_SECRET}
+    max_time: 300
+    verify: false
+
+  - step:
+      action: ASSETS_CREATE_IF_NOT_EXISTS
+      description: Create Acme Asset
+      archivist_label: ACME Corporation
+      asset_label: ACME Asset
+      print_response: true
+    selector:
+      - attributes:
+        - arc_display_name
+        - arc_namespace
+    behaviours:
+      - RecordEvidence
+      - Attachments
+    attributes:
+      arc_display_name: acme_display_name
+      arc_description: acme_display_description
+      arc_namespace: !ENV ${TEST_NAMESPACE:namespace}
+      arc_display_type: acme_display_type
+      ext_vendor_name: acme
+    confirm: true
+
+  # Weyland corporation
+  - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection for Weyland
+      archivist_label: Weyland Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN_2}
+    client_id: !ENV ${TEST_CLIENT_ID_2}
+    client_secret: !ENV ${TEST_CLIENT_SECRET_2}
+    max_time: 300
+    verify: false
+
+  - step:
+      action: SUBJECTS_SHARE
+      description: Share between ACME and Weyland
+      print_response: true
+      archivist_label: ACME Corporation
+    name: Weyland Self on ACME
+    other_name: ACME Self on Weyland
+    other_archivist: Weyland Corporation
+    
+
+# - step:
+#     action: ACCESS_POLICIES_CREATE
+#     description: Create an access_policies entity that allows sharing acme assets
+#     print_response: true
+#     archivist_label: ACME Corporation
+#     access_policy_label: ACME access policy for weyland
+#   display_name: acme access policy for weyland
+#   description: acme Policy description
+#   filters:
+#     - or:
+#       - "attributes.arc_display_type=acme_display_type" 
+#     - or:
+#       - "attributes.ext_vendor_name=acme"
+#   access_permissions:
+#       subjects:
+#         - Weyland Self on acme
+#       behaviours:
+#         - Attachments
+#         - RecordEvidence
+#       include_attributes:
+#         - arc_display_name
+
+# - step:
+#     action: ACCESS_POLICIES_COUNT
+#     description: Count all access_policies
+#     print_response: true
+#     archivist_label: ACME Corporation
+
+# - step:
+#     action: ACCESS_POLICIES_LIST
+#     description: List all access_policies
+#     print_response: true
+#     archivist_label: ACME Corporation
+
+# - step:
+#     action: ACCESS_POLICIES_LIST_MATCHING_ASSETS
+#     description: List assets that match an access_policy
+#     print_response: true
+#     archivist_label: ACME Corporation
+#     access_policy_label: An access policy
+
+# - step:
+#     action: ACCESS_POLICIES_LIST_MATCHING_ACCESS_POLICIES
+#     description: List access policies that match an asset in acme
+#     print_response: true
+#     archivist_label: ACME Corporation
+#     asset_label: An asset
+
+# - step:
+#     action: ACCESS_POLICIES_READ
+#     description: Read access policy
+#     print_response: true
+#     archivist_label: ACME Corporation
+#     access_policy_label: An access policy
+
+##- step:
+##    action: ACCESS_POLICIES_UPDATE
+##    description: Update an access_policies entity.
+##    print_response: true
+##    archivist_label: ACME Corporation
+##    access_policy_label: An access policy

--- a/functests/test_resources/door_entry_story.yaml
+++ b/functests/test_resources/door_entry_story.yaml
@@ -10,6 +10,17 @@
 #
 steps:
   - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection
+      archivist_label: ACME Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN}
+    client_id: !ENV ${TEST_CLIENT_ID}
+    client_secret: !ENV ${TEST_CLIENT_SECRET}
+    max_time: 300
+    verify: false
+
+  - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a door in Paris at RKVST offices.
       asset_label: RKVST Paris Front Door
@@ -49,6 +60,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a door in Paris at City Hall
+      archivist_label: ACME Corporation
       asset_label: City Hall Paris Front Door
     selector:
       - attributes:
@@ -87,6 +99,7 @@ steps:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a door in Paris at Courts of Justice
       print_response: true
+      archivist_label: ACME Corporation
       asset_label: Courts of Justice Paris Front Door
     selector:
       - attributes:
@@ -124,6 +137,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a door in Paris at Bastille
+      archivist_label: ACME Corporation
       asset_label: Bastille Paris Front Door
     selector:
       - attributes:
@@ -161,6 +175,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a front door in Paris at Gare du Nord Apartments
+      archivist_label: ACME Corporation
       asset_label: Gare du Nord Apartments Paris Front Door
     selector:
       - attributes:
@@ -198,6 +213,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a side door in Paris at Gare du Nord Apartments
+      archivist_label: ACME Corporation
       asset_label: Gare du Nord Apartments Paris Side Door
     selector:
       - attributes:
@@ -242,6 +258,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 1
+      archivist_label: ACME Corporation
       asset_label: Access Card 1
     selector:
       - attributes:
@@ -261,6 +278,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 2
+      archivist_label: ACME Corporation
       asset_label: Access Card 2
       print_response: true
     selector:
@@ -281,6 +299,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 3
+      archivist_label: ACME Corporation
       asset_label: Access Card 3
     selector:
       - attributes:
@@ -299,6 +318,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 4
+      archivist_label: ACME Corporation
       asset_label: Access Card 4
     selector:
       - attributes:
@@ -318,6 +338,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 5
+      archivist_label: ACME Corporation
       asset_label: Access Card 5
     selector:
       - attributes:
@@ -340,6 +361,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Courts of justice front door opened with card 2
+      archivist_label: ACME Corporation
       asset_label: Courts of Justice Paris Front Door
       print_response: true
     operation: Record
@@ -363,8 +385,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Access Card 2 opens Courts of justice front door
-      asset_label: Access Card 2
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Access Card 2
     operation: Record
     behaviour: RecordEvidence
     principal_declared:
@@ -387,6 +410,7 @@ steps:
       action: ASSETS_LIST
       description: List all doors
       print_response: true
+      archivist_label: ACME Corporation
     attrs:
       arc_display_type: door
       arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
@@ -395,6 +419,7 @@ steps:
       action: ASSETS_LIST
       description: List all cards
       print_response: true
+      archivist_label: ACME Corporation
     attrs:
       arc_display_type: card
       arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
@@ -403,10 +428,12 @@ steps:
       action: EVENTS_LIST
       description: List all events for Courts of Justice Paris Front Door
       print_response: true
+      archivist_label: ACME Corporation
       asset_label: Courts of Justice Paris Front Door
 
   - step:
       action: EVENTS_LIST
       description: List all events for Access Card 2
       print_response: true
+      archivist_label: ACME Corporation
       asset_label: Access Card 2

--- a/functests/test_resources/dynamic_tolerance_story.yaml
+++ b/functests/test_resources/dynamic_tolerance_story.yaml
@@ -11,8 +11,20 @@
 # as a boolean.
 steps:
   - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection
+      archivist_label: ACME Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN}
+    client_id: !ENV ${TEST_CLIENT_ID}
+    client_secret: !ENV ${TEST_CLIENT_SECRET}
+    max_time: 300
+    verify: false
+
+  - step:
       action: ASSETS_CREATE
       description: Create new EV Pump with id 1.
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     behaviours:
       - RecordEvidence
@@ -29,6 +41,7 @@ steps:
       description: Create a compliance policy that checks an EV pump maintenance requests are serviced within a reasonable time frame.
       print_response: true
       delete: true
+      archivist_label: ACME Corporation
     description: ev maintenance policy
     display_name: ev maintenance policy
     compliance_type: COMPLIANCE_DYNAMIC_TOLERANCE
@@ -43,6 +56,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event requesting EV pump 1 needs maintenance.
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
@@ -56,6 +70,7 @@ steps:
       action: EVENTS_CREATE
       description: Create Event after 1 seconds, for EV pump 1, stating maintenance occurred.
       wait_time: 1
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
@@ -68,6 +83,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event requesting EV pump 1 needs maintenance.
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
@@ -81,6 +97,7 @@ steps:
       action: EVENTS_CREATE
       description: Create Event after 2 seconds, for EV pump 1, stating maintenance occurred.
       wait_time: 2
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
@@ -93,6 +110,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event requesting EV pump 1 needs maintenance.
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
@@ -106,6 +124,7 @@ steps:
       action: EVENTS_CREATE
       description: Create Event after 3 seconds, for EV pump 1, stating maintenance occurred.
       wait_time: 3
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
@@ -119,12 +138,14 @@ steps:
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of EV pump 1.
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
 
   # now create an event that throws the Standard deviation out of whack
   - step:
       action: EVENTS_CREATE
       description: Create Event requesting EV pump 1 needs maintenance.
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
@@ -138,6 +159,7 @@ steps:
       action: EVENTS_CREATE
       description: Create Event after 20 seconds, for EV pump 1, stating maintenance occurred.
       wait_time: 20
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     operation: Record
     behaviour: RecordEvidence
@@ -151,6 +173,7 @@ steps:
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of EV pump 1.
+      archivist_label: ACME Corporation
       asset_label: ev pump 1
     report: true
 

--- a/functests/test_resources/estate_info_story.yaml
+++ b/functests/test_resources/estate_info_story.yaml
@@ -5,5 +5,17 @@
 # This story Evaluates how many assets and events exist.
 steps:
   - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection
+      archivist_label: ACME Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN}
+    client_id: !ENV ${TEST_CLIENT_ID}
+    client_secret: !ENV ${TEST_CLIENT_SECRET}
+    max_time: 300
+    verify: false
+
+  - step:
       action: COMPOSITE_ESTATE_INFO
       description: Check assets, events and locations
+      archivist_label: ACME Corporation

--- a/functests/test_resources/richness_story.yaml
+++ b/functests/test_resources/richness_story.yaml
@@ -8,8 +8,20 @@
 # be of the correct type such as confirm which is a boolean.
 steps:
   - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection
+      archivist_label: ACME Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN}
+    client_id: !ENV ${TEST_CLIENT_ID}
+    client_secret: !ENV ${TEST_CLIENT_SECRET}
+    max_time: 300
+    verify: false
+
+  - step:
       action: ASSETS_CREATE
       description: Create an empty radiation bag with id 1.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 1
     behaviours:
       - RecordEvidence
@@ -25,6 +37,7 @@ steps:
   - step:
       action: ASSETS_CREATE
       description: Create an empty radiation bag with id 2.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 2
     behaviours:
       - RecordEvidence
@@ -40,6 +53,7 @@ steps:
   - step:
       action: ASSETS_CREATE
       description: Create an empty radiation bag with id 3.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 3
     behaviours:
       - RecordEvidence
@@ -58,6 +72,7 @@ steps:
       description: Create a compliance policy that checks the radiation level of radiation bags is less than 7 rads.
       print_response: true
       delete: true
+      archivist_label: ACME Corporation
     description: radiation level safety policy
     display_name: radiation safety policy
     compliance_type: COMPLIANCE_RICHNESS
@@ -72,6 +87,7 @@ steps:
       description: Create a compliance policy that checks the weight of a radiation bag is less than or equal to 10kg.
       print_response: true
       delete: true
+      archivist_label: ACME Corporation
     description: weight level safety policy
     display_name: weight safety policy
     compliance_type: COMPLIANCE_RICHNESS
@@ -86,6 +102,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event adding 3 rads of radiation to bag 1, increasing its weight by 1kg.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 1
     operation: Record
     behaviour: RecordEvidence
@@ -99,6 +116,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event adding 2 rads of radiation to bag 2, increasing its weight by 5kg.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 2
     operation: Record
     behaviour: RecordEvidence
@@ -112,6 +130,7 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Create Event adding 5 rads of radiation to bag 3, increasing its weight by 7kg.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 3
     operation: Record
     behaviour: RecordEvidence
@@ -127,16 +146,19 @@ steps:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of bag 1.
       print_response: True
+      archivist_label: ACME Corporation
       asset_label: radiation bag 1
 
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of bag 2.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 2
 
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of bag 3.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 3
 
   # now attempt to add waste to tip one over the edge
@@ -144,6 +166,7 @@ steps:
       action: EVENTS_CREATE
       description: Now Create Event adding 4 rads of radiation to bag 3 increasing its weight by 1kg.
                    This brings the total radiation level to 9 rads and weight to 8kg.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 3
     operation: Record
     behaviour: RecordEvidence
@@ -158,5 +181,6 @@ steps:
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of bag 3.
+      archivist_label: ACME Corporation
       asset_label: radiation bag 3
     report: true

--- a/functests/test_resources/sbom_story.yaml
+++ b/functests/test_resources/sbom_story.yaml
@@ -11,8 +11,20 @@
 #
 steps:
   - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection
+      archivist_label: ACME Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN}
+    client_id: !ENV ${TEST_CLIENT_ID}
+    client_secret: !ENV ${TEST_CLIENT_SECRET}
+    max_time: 300
+    verify: false
+
+  - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create the ACME Corporation Detector SAAS SBOM
+      archivist_label: ACME Corporation
       asset_label: ACME Corporation Detector SAAS
     selector:
       - attributes:
@@ -38,8 +50,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Release YYYYMMDD.1 of Test SBOM for YAML story
-      asset_label: ACME Corporation Detector SAAS
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: ACME Corporation Detector SAAS
     operation: Record
     behaviour: RecordEvidence
     confirm: true
@@ -56,8 +69,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Release YYYYMMDD.2 of Test SBOM for YAML story
-      asset_label: ACME Corporation Detector SAAS
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: ACME Corporation Detector SAAS
     operation: Record
     behaviour: RecordEvidence
     confirm: true
@@ -74,8 +88,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Release YYYYMMDD.3 of Test SBOM for YAML story
-      asset_label: ACME Corporation Detector SAAS
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: ACME Corporation Detector SAAS
     operation: Record
     behaviour: RecordEvidence
     confirm: true
@@ -92,6 +107,7 @@ steps:
       action: ASSETS_LIST
       description: List all sboms
       print_response: true
+      archivist_label: ACME Corporation
     attrs:
       arc_display_type: Software Package
       arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
@@ -100,6 +116,7 @@ steps:
       action: EVENTS_LIST
       description: List all releases for this sbom
       print_response: true
+      archivist_label: ACME Corporation
       asset_label: ACME Corporation Detector SAAS
     props:
       confirmation_status: CONFIRMED

--- a/functests/test_resources/subjects_story.yaml
+++ b/functests/test_resources/subjects_story.yaml
@@ -1,9 +1,21 @@
 ---
 steps:
   - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection
+      archivist_label: ACME Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN}
+    client_id: !ENV ${TEST_CLIENT_ID}
+    client_secret: !ENV ${TEST_CLIENT_SECRET}
+    max_time: 300
+    verify: false
+
+  - step:
       action: SUBJECTS_CREATE
       description: Create a subjects entity.
       print_response: true
+      archivist_label: ACME Corporation
       subject_label: A subject
     display_name: A subject
     wallet_pub_key:
@@ -15,6 +27,7 @@ steps:
       action: SUBJECTS_CREATE_FROM_B64
       description: Import a subjects entity.
       print_response: true
+      archivist_label: ACME Corporation
       subject_label: An imported subject
     display_name: An imported subject
     subject_string: >-
@@ -34,22 +47,26 @@ steps:
       action: SUBJECTS_COUNT
       description: Count all subjects
       print_response: true
+      archivist_label: ACME Corporation
 
   - step:
       action: SUBJECTS_LIST
       description: List all subjects
       print_response: true
+      archivist_label: ACME Corporation
 
   - step:
       action: SUBJECTS_READ
       description: Read subject
       print_response: true
+      archivist_label: ACME Corporation
       subject_label: A subject
 
   - step:
       action: SUBJECTS_UPDATE
       description: Update a subjects entity.
       print_response: true
+      archivist_label: ACME Corporation
       subject_label: A subject
     wallet_pub_key:
       - 04c1173bf7844bf1c607b79c18db091b9558ffe581bf132b8cf3b37657230fa321a0880b54a79a88b28bc710ede6dcf3d8272c5210bfd41ea83188e385d12c189c
@@ -58,10 +75,12 @@ steps:
       action: SUBJECTS_DELETE
       description: Delete subject
       print_response: true
+      archivist_label: ACME Corporation
       subject_label: A subject
 
   - step:
       action: SUBJECTS_DELETE
       description: Delete subject
       print_response: true
+      archivist_label: ACME Corporation
       subject_label: An imported subject

--- a/functests/test_resources/synsation_story.yaml.j2
+++ b/functests/test_resources/synsation_story.yaml.j2
@@ -5,6 +5,16 @@
 # cameras
 #
 steps:
+  - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection
+      archivist_label: ACME Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN}
+    client_id: !ENV ${TEST_CLIENT_ID}
+    client_secret: !ENV ${TEST_CLIENT_SECRET}
+    max_time: 300
+    verify: false
 
   # create locations for all offices - these are created separately as more than one asset
   # can be located at an office and we dont want to duplicate code...
@@ -13,6 +23,7 @@ steps:
   - step:
       action: LOCATIONS_CREATE_IF_NOT_EXISTS
       description: Create {{ location.display_name }} Location
+      archivist_label: ACME Corporation
       location_label: {{ location.display_name }}
     selector:
       - display_name
@@ -33,6 +44,7 @@ steps:
       action: LOCATIONS_COUNT
       description: Count locations in namespace
       print_response: true
+      archivist_label: ACME Corporation
     attrs:
       namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
 
@@ -40,6 +52,7 @@ steps:
       action: LOCATIONS_LIST
       description: List locations in namespace
       print_response: true
+      archivist_label: ACME Corporation
     attrs:
       namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
 
@@ -47,6 +60,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a {{ asset.type }} in {{ asset.location_label }}
+      archivist_label: ACME Corporation
       asset_label: {{ asset.asset_label }}
       location_label: {{ asset.location_label }}
     selector:
@@ -74,6 +88,7 @@ steps:
       action: ASSETS_WAIT_FOR_CONFIRMED
       description: Wait for all assets to be confirmed
       print_response: true
+      archivist_label: ACME Corporation
     attrs:
       arc_namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
 
@@ -81,6 +96,7 @@ steps:
       action: ASSETS_LIST
       description: List all printers
       print_response: true
+      archivist_label: ACME Corporation
     attrs:
       arc_display_type: printer
       arc_namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
@@ -89,6 +105,7 @@ steps:
       action: ASSETS_LIST
       description: List all coffee machines
       print_response: true
+      archivist_label: ACME Corporation
     attrs:
       arc_display_type: coffee machine
       arc_namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
@@ -97,6 +114,7 @@ steps:
       action: ASSETS_LIST
       description: List all security cameras
       print_response: true
+      archivist_label: ACME Corporation
     attrs:
       arc_display_type: security camera
       arc_namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"

--- a/functests/test_resources/wipp_story.yaml
+++ b/functests/test_resources/wipp_story.yaml
@@ -6,8 +6,20 @@
 #
 steps:
   - step:
+      action: ARCHIVIST_CREATE
+      description: Create an archivist connection
+      archivist_label: ACME Corporation
+    url: !ENV ${TEST_ARCHIVIST:https://app.rkvst.io}
+    auth_token: !ENV ${TEST_AUTHTOKEN}
+    client_id: !ENV ${TEST_CLIENT_ID}
+    client_secret: !ENV ${TEST_CLIENT_SECRET}
+    max_time: 300
+    verify: false
+
+  - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a drum container number 1
+      archivist_label: ACME Corporation
       asset_label: Drum 1
     selector:
       - attributes:
@@ -31,6 +43,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a cask container number 1
+      archivist_label: ACME Corporation
       asset_label: Cask 1
     selector:
       - attributes:
@@ -54,8 +67,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Characterize Drum 1
-      asset_label: Drum 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Drum 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -79,8 +93,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Tomograph Drum 1
-      asset_label: Drum 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Drum 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -105,8 +120,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Loading Drum 1 into Cask 1
-      asset_label: Drum 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Drum 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -124,8 +140,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Filled Cask 1 with Drum 1
-      asset_label: Cask 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Cask 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -143,8 +160,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Preship inspection of Drum 1
-      asset_label: Drum 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Drum 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -160,8 +178,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Preship inspection of Cask 1
-      asset_label: Cask 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Cask 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -177,8 +196,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Departure of Drum 1
-      asset_label: Drum 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Drum 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -197,8 +217,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Departure of Cask 1
-      asset_label: Cask 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Cask 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -218,8 +239,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Atlanta Waypoint of Cask 1
-      asset_label: Cask 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Cask 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -248,8 +270,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Talladega Waypoint of Cask 1
-      asset_label: Cask 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Cask 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -279,8 +302,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Arrival of Drum 1
-      asset_label: Drum 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Drum 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -296,8 +320,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Arrival of Cask 1
-      asset_label: Cask 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Cask 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -314,8 +339,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Unloading Drum 1 from Cask 1
-      asset_label: Drum 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Drum 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -331,8 +357,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Unloading Drum 1 from Cask 1
-      asset_label: Cask 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Cask 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -349,8 +376,9 @@ steps:
   - step:
       action: EVENTS_CREATE
       description: Drum 1 Emplacemant
-      asset_label: Drum 1
       print_response: true
+      archivist_label: ACME Corporation
+      asset_label: Drum 1
     operation: Record
     behaviour: RecordEvidence
     event_attributes:

--- a/unittests/testrunner.py
+++ b/unittests/testrunner.py
@@ -12,10 +12,9 @@ from unittest import TestCase
 # pylint: disable=unused-variable
 
 from archivist.archivist import Archivist
-from archivist.assets import Asset
 from archivist.constants import ASSET_BEHAVIOURS
 from archivist.logger import set_logger
-from archivist.runner import tree
+from archivist.runner import Runner
 
 if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
     set_logger(environ["TEST_DEBUG"])
@@ -57,6 +56,7 @@ class TestRunner(TestCase):
 
     def setUp(self):
         self.arch = Archivist("url", "authauthauth")
+        self.runner = Runner()
 
     def tearDown(self):
         self.arch.close()
@@ -66,24 +66,7 @@ class TestRunner(TestCase):
         Test runner str
         """
         self.assertEqual(
-            str(self.arch.runner),
-            "Runner(url)",
+            str(self.runner),
+            "Runner()",
             msg="Incorrect str",
-        )
-
-    def test_runner_asset_id(self):
-        """
-        Test runner asset_id
-        """
-        runner = self.arch.runner
-        runner.entities = tree()
-        runner.entities[ASSET_NAME] = Asset(**ASSETS_RESPONSE)
-        self.assertEqual(
-            runner.identity(ASSET_NAME),
-            ASSET_ID,
-            msg="Incorrect ID",
-        )
-        self.assertIsNone(
-            runner.identity(ASSET_NAME + "garbage"),
-            msg="Incorrect ID",
         )

--- a/unittests/testrunneractiomap.py
+++ b/unittests/testrunneractiomap.py
@@ -3,7 +3,7 @@ Test runner actionmap
 """
 from logging import getLogger
 from os import environ
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from archivist.errors import ArchivistInvalidOperationError
 
@@ -12,13 +12,29 @@ from archivist.errors import ArchivistInvalidOperationError
 # pylint: disable=unused-variable
 
 from archivist.archivist import Archivist
-from archivist.runner import _ActionMap
+from archivist.confirmer import MAX_TIME
 from archivist.logger import set_logger
+from archivist.runner import _ActionMap, Runner
 
 if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
     set_logger(environ["TEST_DEBUG"])
 
 LOGGER = getLogger(__name__)
+
+
+URL = "https://app.rkvst-dev.io"
+AUTH_TOKEN = "auth_token"
+ARCHIVIST_CREATE = {
+    "url": URL,
+    "auth_token": AUTH_TOKEN,
+    "max_time": 257,
+    "verify": False,
+}
+ARCHIVIST_CREATE_APPREG = {
+    "url": URL,
+    "client_id": "client_id",
+    "client_secret": "client_secret",
+}
 
 
 class TestRunnerActionMap(TestCase):
@@ -31,6 +47,10 @@ class TestRunnerActionMap(TestCase):
     def setUp(self):
         self.arch = Archivist("url", "authauthauth")
         self.actionmap = _ActionMap(self.arch)
+        self.runner = Runner()
+
+    def tearDown(self):
+        self.arch.close()
 
     def tearDown(self):
         self.arch.close()
@@ -51,3 +71,83 @@ class TestRunnerActionMap(TestCase):
         """
         with self.assertRaises(ArchivistInvalidOperationError):
             _ = self.actionmap.action("ASSETSS_CREATE")
+
+    @mock.patch("archivist.runner.Archivist")
+    @mock.patch("archivist.runner.time_sleep")
+    def test_runner_archivist_create_with_token(self, mock_sleep, mock_archivist):
+        """
+        Test runner operation
+        """
+        self.runner(
+            {
+                "steps": [
+                    {
+                        "step": {
+                            "action": "ARCHIVIST_CREATE",
+                            "wait_time": 10,
+                            "description": "Testing runner assets create",
+                            "archivist_label": "Archivist3456xx",
+                        },
+                        **ARCHIVIST_CREATE,
+                    },
+                ],
+            }
+        )
+        args, kwargs = mock_archivist.call_args
+
+        self.assertEqual(
+            args,
+            (URL, AUTH_TOKEN),
+            msg="Incorrect args in archivist create",
+        )
+        self.assertEqual(
+            kwargs,
+            {
+                "max_time": 257,
+                "verify": False,
+            },
+            msg="Incorrect keywords args",
+        )
+        self.assertTrue(
+            "Archivist3456xx" in self.runner.entities,
+            msg="Incorrect Archivist",
+        )
+        mock_sleep.assert_called_once_with(10)
+
+    @mock.patch("archivist.runner.Archivist")
+    @mock.patch("archivist.runner.time_sleep")
+    def test_runner_archivist_create_with_appreg(self, mock_sleep, mock_archivist):
+        """
+        Test runner operation
+        """
+        self.runner(
+            {
+                "steps": [
+                    {
+                        "step": {
+                            "action": "ARCHIVIST_CREATE",
+                            "wait_time": 10,
+                            "description": "Testing runner assets create",
+                            "archivist_label": "Archivist 123ZZ",
+                        },
+                        **ARCHIVIST_CREATE_APPREG,
+                    },
+                ],
+            }
+        )
+        args, kwargs = mock_archivist.call_args
+
+        self.assertEqual(
+            args,
+            (URL, ("client_id", "client_secret")),
+            msg="Incorrect args in archivist create",
+        )
+        self.assertEqual(
+            kwargs,
+            {
+                "max_time": MAX_TIME,
+                "verify": True,
+            },
+            msg="Incorrect keywords args",
+        )
+        mock_sleep.assert_called_once_with(10)

--- a/unittests/testrunnerlocation.py
+++ b/unittests/testrunnerlocation.py
@@ -13,11 +13,9 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.locations import Location
-from archivist.constants import (
-    LOCATIONS_LABEL,
-)
-
+from archivist.constants import LOCATIONS_LABEL
 from archivist.logger import set_logger
+from archivist.runner import Runner
 
 if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
     set_logger(environ["TEST_DEBUG"])
@@ -66,6 +64,8 @@ class TestRunnerLocationsCreate(TestCase):
 
     def setUp(self):
         self.arch = Archivist("url", "authauthauth")
+        self.runner = Runner()
+        self.runner.entities["TestArchivist"] = self.arch
 
     def tearDown(self):
         self.arch.close()
@@ -79,7 +79,7 @@ class TestRunnerLocationsCreate(TestCase):
             self.arch.locations, "create_if_not_exists"
         ) as mock_locations_create:
             mock_locations_create.return_value = Location(**LOCATIONS_RESPONSE)
-            self.arch.runner(
+            self.runner(
                 {
                     "steps": [
                         {
@@ -87,6 +87,7 @@ class TestRunnerLocationsCreate(TestCase):
                                 "action": "LOCATIONS_CREATE_IF_NOT_EXISTS",
                                 "wait_time": 10,
                                 "description": "Testing runner locations create",
+                                "archivist_label": "TestArchivist",
                                 "location_label": "Existing Location",
                             },
                             **LOCATIONS_CREATE,
@@ -95,9 +96,4 @@ class TestRunnerLocationsCreate(TestCase):
                 }
             )
             mock_locations_create.assert_called_once_with(LOCATIONS_CREATE)
-            self.assertEqual(
-                self.arch.runner.entities["Existing Location"],
-                LOCATIONS_RESPONSE,
-                msg="Incorrect location created",
-            )
             mock_sleep.assert_called_once_with(10)

--- a/unittests/testrunnerstep.py
+++ b/unittests/testrunnerstep.py
@@ -49,16 +49,17 @@ class TestRunnerStep(TestCase):
         Test runner step
         """
         step = _Step(
-            self.arch,
             **{
                 "action": "COMPLIANCE_POLICIES_CREATE",
                 "wait_time": 10,
                 "print_response": True,
                 "description": "Testing runner events list",
-                "asset_label": "Existing Asset",
                 "delete": True,
+                "archivist_label": "TestArchivist",
+                "asset_label": "Existing Asset",
             }
         )
+        step._archivist = self.arch
         self.assertEqual(
             step.action,
             self.arch.compliance_policies.create_from_data,
@@ -88,16 +89,17 @@ class TestRunnerStep(TestCase):
         Test runner step
         """
         step = _Step(
-            self.arch,
             **{
                 "action": "EVENTS_LIST",
                 "wait_time": 10,
                 "print_response": True,
                 "description": "Testing runner events list",
-                "asset_label": "Existing Asset",
                 "delete": True,
+                "archivist_label": "TestArchivist",
+                "asset_label": "Existing Asset",
             }
         )
+        step._archivist = self.arch
         self.assertEqual(
             step.action,
             self.arch.events.list,
@@ -175,15 +177,16 @@ class TestRunnerStep(TestCase):
         Test runner step
         """
         step = _Step(
-            self.arch,
             **{
                 "action": "EVENTS_CREATE",
                 "wait_time": 10,
                 "print_response": True,
                 "description": "Testing runner events list",
+                "archivist_label": "TestArchivist",
                 "location_label": "Existing Location",
             }
         )
+        step._archivist = self.arch
         self.assertEqual(
             step.action,
             self.arch.events.create_from_data,

--- a/unittests/testsubjects.py
+++ b/unittests/testsubjects.py
@@ -15,6 +15,10 @@ from archivist.constants import (
 )
 from archivist.errors import ArchivistBadRequestError, ArchivistUnconfirmedError
 from archivist.logger import set_logger
+<<<<<<< HEAD
+=======
+from archivist.runner import Runner
+>>>>>>> 0730e99 (Access Policy Runner Story)
 
 from .mock_response import MockResponse
 
@@ -105,6 +109,10 @@ class TestSubjects(TestCase):
     def setUp(self):
         self.arch = Archivist("url", "authauthauth", max_time=1)
         self.arch2 = Archivist("url", "authauthauth", max_time=1)
+<<<<<<< HEAD
+=======
+        self.runner = Runner()
+>>>>>>> 0730e99 (Access Policy Runner Story)
 
     def test_subjects_str(self):
         """
@@ -586,3 +594,331 @@ class TestSubjectsConfirm(TestCase):
                     RESPONSE_WITH_CONFIRMATION,
                     msg="wait_for_confirmation called incorrectly",
                 )
+
+
+class TestSubjectsRunner(TestCase):
+    """
+    Test Archivist Subjects using Runner
+    """
+
+    maxDiff = None
+
+    def setUp(self):
+        self.arch = Archivist("url", "authauthauth", max_time=1)
+        self.runner = Runner()
+        self.runner.entities["TestArchivist"] = self.arch
+        self.runner.entities["Existing Subject"] = RESPONSE
+
+    @mock.patch("archivist.runner.time_sleep")
+    def test_subjects_create(self, mock_sleep):
+        """
+        Test subject creation
+        """
+        with mock.patch.object(self.arch.session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+
+            self.runner(
+                {
+                    "steps": [
+                        {
+                            "step": {
+                                "action": "SUBJECTS_CREATE",
+                                "wait_time": 10,
+                                "description": "Testing runner subjects create",
+                                "archivist_label": "TestArchivist",
+                                "subject_label": "Existing Subject",
+                            },
+                            **REQUEST,
+                        },
+                    ],
+                }
+            )
+
+            args, kwargs = mock_post.call_args
+            self.assertEqual(
+                args,
+                (f"url/{ROOT}/{SUBPATH}",),
+                msg="CREATE method args called incorrectly",
+            )
+            self.assertEqual(
+                kwargs,
+                {
+                    "json": REQUEST,
+                    "headers": {
+                        "authorization": "Bearer authauthauth",
+                    },
+                    "verify": True,
+                },
+                msg="CREATE method kwargs called incorrectly",
+            )
+            self.assertEqual(
+                self.runner.entities["Existing Subject"],
+                RESPONSE,
+                msg="Incorrect subject created",
+            )
+            mock_sleep.assert_called_once_with(10)
+
+    @mock.patch("archivist.runner.time_sleep")
+    def test_subjects_create_from_b64(self, mock_sleep):
+        """
+        Test subject creation
+        """
+        with mock.patch.object(self.arch.session, "post") as mock_post:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+
+            self.runner(
+                {
+                    "steps": [
+                        {
+                            "step": {
+                                "action": "SUBJECTS_CREATE_FROM_B64",
+                                "wait_time": 10,
+                                "description": "Testing runner subjects create",
+                                "archivist_label": "TestArchivist",
+                                "subject_label": "Existing Subject",
+                            },
+                            "display_name": DISPLAY_NAME,
+                            "subject_string": SUBJECT_STRING,
+                        },
+                    ],
+                }
+            )
+            args, kwargs = mock_post.call_args
+            self.assertEqual(
+                args,
+                (f"url/{ROOT}/{SUBPATH}",),
+                msg="CREATE method args called incorrectly",
+            )
+            self.assertEqual(
+                kwargs,
+                {
+                    "json": REQUEST,
+                    "headers": {
+                        "authorization": "Bearer authauthauth",
+                    },
+                    "verify": True,
+                },
+                msg="CREATE method kwargs called incorrectly",
+            )
+            self.assertEqual(
+                self.runner.entities["Existing Subject"],
+                RESPONSE,
+                msg="Incorrect subject created",
+            )
+            mock_sleep.assert_called_once_with(10)
+
+    @mock.patch("archivist.runner.time_sleep")
+    def test_subjects_story_read_update_delete(self, mock_sleep):
+        """
+        Test subject reading
+        """
+        with mock.patch.object(
+            self.arch.session, "post"
+        ) as mock_post, mock.patch.object(
+            self.arch.session, "get"
+        ) as mock_get, mock.patch.object(
+            self.arch.session, "patch"
+        ) as mock_patch, mock.patch.object(
+            self.arch.session, "delete"
+        ) as mock_delete:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.return_value = MockResponse(200, **RESPONSE)
+            mock_patch.return_value = MockResponse(200, **RESPONSE)
+            mock_delete.return_value = MockResponse(200, {})
+
+            self.runner(
+                {
+                    "steps": [
+                        {
+                            "step": {
+                                "action": "SUBJECTS_CREATE_FROM_B64",
+                                "wait_time": 1,
+                                "description": "Testing runner subjects create",
+                                "archivist_label": "TestArchivist",
+                                "subject_label": "Existing Subject",
+                            },
+                            "display_name": DISPLAY_NAME,
+                            "subject_string": SUBJECT_STRING,
+                        },
+                        {
+                            "step": {
+                                "action": "SUBJECTS_READ",
+                                "wait_time": 2,
+                                "description": "Testing runner subjects read",
+                                "archivist_label": "TestArchivist",
+                                "subject_label": "Existing Subject",
+                            },
+                        },
+                        {
+                            "step": {
+                                "action": "SUBJECTS_UPDATE",
+                                "wait_time": 3,
+                                "description": "Testing runner subjects update",
+                                "archivist_label": "TestArchivist",
+                                "subject_label": "Existing Subject",
+                            },
+                            "display_name": DISPLAY_NAME,
+                        },
+                        {
+                            "step": {
+                                "action": "SUBJECTS_DELETE",
+                                "wait_time": 4,
+                                "description": "Testing runner subjects delete`",
+                                "archivist_label": "TestArchivist",
+                                "subject_label": "Existing Subject",
+                            },
+                        },
+                    ],
+                }
+            )
+            self.assertEqual(
+                tuple(mock_get.call_args),
+                (
+                    ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
+                    {
+                        "headers": {
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "params": None,
+                        "verify": True,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+            args, kwargs = mock_patch.call_args
+            self.assertEqual(
+                args,
+                (f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}",),
+                msg="PATCH method args called incorrectly",
+            )
+            self.assertEqual(
+                kwargs,
+                {
+                    "json": UPDATE,
+                    "headers": {
+                        "authorization": "Bearer authauthauth",
+                    },
+                    "verify": True,
+                },
+                msg="PATCH method kwargs called incorrectly",
+            )
+            self.assertEqual(
+                tuple(mock_delete.call_args),
+                (
+                    ((f"url/{ROOT}/{SUBJECTS_SUBPATH}/{IDENTITY}"),),
+                    {
+                        "headers": {
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "verify": True,
+                    },
+                ),
+                msg="DELETE method called incorrectly",
+            )
+            self.assertEqual(
+                mock_sleep.call_args_list,
+                [mock.call(1), mock.call(2), mock.call(3), mock.call(4)],
+                msg="Sleep method called incorrectly",
+            )
+
+    @mock.patch("archivist.runner.time_sleep")
+    def test_subjects_story_list_and_count(self, mock_sleep):
+        """
+        Test subject listing
+        """
+        with mock.patch.object(
+            self.arch.session, "post"
+        ) as mock_post, mock.patch.object(self.arch.session, "get") as mock_get:
+            mock_post.return_value = MockResponse(200, **RESPONSE)
+            mock_get.side_effect = [
+                MockResponse(
+                    200,
+                    subjects=[
+                        RESPONSE,
+                    ],
+                ),
+                MockResponse(
+                    200,
+                    headers={HEADERS_TOTAL_COUNT: 1},
+                    subjects=[
+                        RESPONSE,
+                    ],
+                ),
+            ]
+
+            self.runner(
+                {
+                    "steps": [
+                        {
+                            "step": {
+                                "action": "SUBJECTS_CREATE_FROM_B64",
+                                "wait_time": 1,
+                                "description": "Testing runner subjects create",
+                                "archivist_label": "TestArchivist",
+                                "subject_label": "Existing Subject",
+                            },
+                            "display_name": DISPLAY_NAME,
+                            "subject_string": SUBJECT_STRING,
+                        },
+                        {
+                            "step": {
+                                "action": "SUBJECTS_LIST",
+                                "wait_time": 2,
+                                "print_response": True,
+                                "description": "Testing runner subjects list",
+                                "archivist_label": "TestArchivist",
+                            },
+                            "display_name": DISPLAY_NAME,
+                        },
+                        {
+                            "step": {
+                                "action": "SUBJECTS_COUNT",
+                                "wait_time": 3,
+                                "print_response": True,
+                                "description": "Testing runner subjects count",
+                                "archivist_label": "TestArchivist",
+                            },
+                            "display_name": DISPLAY_NAME,
+                        },
+                    ],
+                }
+            )
+            # mock_print.assert_called_once_with(10)
+            self.assertEqual(
+                tuple(mock_get.call_args_list[0]),
+                (
+                    ((f"url/{ROOT}/{SUBPATH}"),),
+                    {
+                        "headers": {
+                            "authorization": "Bearer authauthauth",
+                        },
+                        "params": {"display_name": "Subject display name"},
+                        "verify": True,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+
+            self.assertEqual(
+                tuple(mock_get.call_args_list[1]),
+                (
+                    ((f"url/{ROOT}/{SUBPATH}"),),
+                    {
+                        "headers": {
+                            "authorization": "Bearer authauthauth",
+                            HEADERS_REQUEST_TOTAL_COUNT: "true",
+                        },
+                        "params": {
+                            "display_name": "Subject display name",
+                            "page_size": 1,
+                        },
+                        "verify": True,
+                    },
+                ),
+                msg="GET method called incorrectly",
+            )
+            self.assertEqual(
+                mock_sleep.call_args_list,
+                [mock.call(1), mock.call(2), mock.call(3)],
+                msg="Sleep method called incorrectly",
+            )


### PR DESCRIPTION
Problem:
Access Policy had no Runner stories.

Solution:
Added story runners for Access Policies. This also requires that the Runner be
independent of the archivist instance. i.e. one must create archivist instances
from the runner.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>