### PR TITLE
Consistent environment variables

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,8 +121,8 @@ they be run in a production environment.
 Set 2 environment variables and execute:
 
 ```bash
-export TEST_ARCHIVIST="https://app.rkvst.io"
-export TEST_AUTHTOKEN_FILENAME=credentials/authtoken
+export RKVST_URL="https://app.rkvst.io"
+export RKVST_AUTHTOKEN_FILENAME=credentials/authtoken
 task functests
 ```
 
@@ -130,39 +130,39 @@ NOTE: For the access policy functional tests, two separate tenancy tokens are ne
       Therefore add a another env variable for the second tenancy's auth token:
 
 ```
-export TEST_AUTHTOKEN_FILENAME_2=credentials/authtoken_tenant_2
+export RKVST_AUTHTOKEN_FILENAME_2=credentials/authtoken_tenant_2
 ```
 
 Alternatively one can use a direct environment variable for the authtoken:
 ```bash
-export TEST_AUTHTOKEN_FILENAME=
-export TEST_AUTHTOKEN="ey.....==="
+export RKVST_AUTHTOKEN_FILENAME=
+export RKVST_AUTHTOKEN="ey.....==="
 task functests
 ```
 
 Alternatively one can use a client id and secret obtained from the appregistrations endpoint:
 ```bash
-export TEST_AUTHTOKEN_FILENAME=
-export TEST_AUTHTOKEN=
-export TEST_CLIENT_ID=c5db8230-6e1c-4b80-9481-d70e647c0429
-export TEST_CLIENT_SECRET_FILENAME=credentials/client_secret
+export RKVST_AUTHTOKEN_FILENAME=
+export RKVST_AUTHTOKEN=
+export RKVST_APPREG_CLIENT=c5db8230-6e1c-4b80-9481-d70e647c0429
+export RKVST_APPREG_SECRET_FILENAME=credentials/client_secret
 task functests
 ```
 
 Additionally one set the appregistration directly in the environment:
 
 ```bash
-export TEST_AUTHTOKEN_FILENAME=
-export TEST_AUTHTOKEN=
-export TEST_CLIENT_ID=c5db8230-6e1c-4b80-9481-d70e647c0429
-export TEST_CLIENT_SECRET_FILENAME=
-export TEST_CLIENT_SECRET="ey.....................ab=="
+export RKVST_AUTHTOKEN_FILENAME=
+export RKVST_AUTHTOKEN=
+export RKVST_APPREG_CLIENT=c5db8230-6e1c-4b80-9481-d70e647c0429
+export RKVST_APPREG_SECRET_FILENAME=
+export RKVST_APPREG_SECRET="ey.....................ab=="
 task functests
 ```
 When running the runner tests one can specify a namespace to isolate instances of assets in differnt 
 runs:
 ```bash
-export ARCHIVIST_NAMESPACE=${RANDOM}
+export RKVST_NAMESPACE=${RANDOM}
 FUNCTEST=execrunner task functests
 ```
 
@@ -171,14 +171,14 @@ Additional environment variables:
 For testing sharing via an access policy requires a second auth token:
 
 ```bash
-TEST_AUTHTOKEN_FILENAME_2=
+RKVST_AUTHTOKEN_FILENAME_2=
 ```
 
 Testing of the client token refresh logic can take 10 to 20 minutes to complete.
 To enable this test set:
 
 ```bash
-TEST_REFRESH_TOKEN=anything
+RKVST_REFRESH_TOKEN=anything
 ```
 
 #### Testing Other Python Versions

--- a/README.rst
+++ b/README.rst
@@ -126,8 +126,8 @@ You can then use the examples code to create assets (see examples directory):
         # client id is an environment variable. client_secret is stored in a file in a
         # directory that has 0700 permissions. The location of this file is set in
         # the client_secret_filename environment variable.
-        client_id = getenv("ARCHIVIST_CLIENT_ID")
-        client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILENAME")
+        client_id = getenv("RKVST_APPREG_CLIENT")
+        client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
         with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
             client_secret = tokenfile.read().strip()
 
@@ -380,8 +380,8 @@ which should be called before anything else:
     from archivist.archivist import Archivist
 
     set_logger("DEBUG")
-    client_id = getenv("ARCHIVIST_CLIENT_ID")
-    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILENAME")
+    client_id = getenv("RKVST_APPREG_CLIENT")
+    client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
     with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
         client_secret = tokenfile.read().strip()
 

--- a/archivist/cmds/runner/run.py
+++ b/archivist/cmds/runner/run.py
@@ -24,7 +24,7 @@ def run(arch: archivist.Archivist, args):
     # if namespace is specified on the commandline then override any environment
     # setting...
     if args.namespace:
-        environ["ARCHIVIST_NAMESPACE"] = args.namespace
+        environ["RKVST_NAMESPACE"] = args.namespace
 
     with open(args.yamlfile, "r", encoding="utf-8") as yml:
         arch.runner(parse_config(data=yml))

--- a/archivist/cmds/template/run.py
+++ b/archivist/cmds/template/run.py
@@ -33,7 +33,7 @@ def run(arch: "type_helper.Archivist", args):
     # if namespace is specified on the commandline then override any environment
     # setting...
     if args.namespace:
-        environ["ARCHIVIST_NAMESPACE"] = args.namespace
+        environ["RKVST_NAMESPACE"] = args.namespace
 
     # environment is injected into the template
     with open(args.values, "r", encoding="utf-8") as fd:

--- a/archivist/notebooks/Create Asset and Events.ipynb
+++ b/archivist/notebooks/Create Asset and Events.ipynb
@@ -58,9 +58,9 @@
     "# URL = represents the url to the RKVST application\n",
     "# CLIENT = represents the client ID from an Application Registration\n",
     "# SECRET = represents the client secret from an Application Registration\n",
-    "RKVST_URL = getenv(\"URL\")\n",
-    "APPREG_CLIENT = getenv(\"CLIENT\")\n",
-    "APPREG_SECRET = getenv(\"SECRET\")"
+    "RKVST_URL = getenv(\"RKVST_URL\")\n",
+    "APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")"
    ]
   },
   {

--- a/archivist/notebooks/Find Asset and Create Attachment.ipynb
+++ b/archivist/notebooks/Find Asset and Create Attachment.ipynb
@@ -64,9 +64,9 @@
     "# URL = represents the url to the RKVST application\n",
     "# CLIENT = represents the client ID from an Application Registration\n",
     "# SECRET = represents the client secret from an Application Registration\n",
-    "RKVST_URL = getenv(\"URL\")\n",
-    "APPREG_CLIENT = getenv(\"CLIENT\")\n",
-    "APPREG_SECRET = getenv(\"SECRET\")"
+    "RKVST_URL = getenv(\"RKVST_URL\")\n",
+    "APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")"
    ]
   },
   {

--- a/archivist/notebooks/Manage_Credentials.ipynb
+++ b/archivist/notebooks/Manage_Credentials.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "# Retrieve the URL\n",
     "\n",
-    "URL = getenv(\"TEST_ARCHIVIST\")\n",
+    "URL = getenv(\"RKVST_URL\")\n",
     "print(\"URL\", URL)"
    ]
   },
@@ -79,7 +79,7 @@
    "source": [
     "# extract JWT from environment\n",
     "\n",
-    "auth_token = getenv(\"TEST_AUTHTOKEN\")\n",
+    "auth_token = getenv(\"RKVST_AUTHTOKEN\")\n",
     "print(\"auth_token\", auth_token)"
    ]
   },
@@ -126,10 +126,10 @@
     "# AppRegistrations POST /archivist/iam/v1/application. Click on 'Try It Out', fill in the request body with a\n",
     "# required display name. Custom claims can be deleted from the example in most cases.\n",
     "\n",
-    "client_id = getenv(\"TEST_CLIENT_ID\")\n",
+    "client_id = getenv(\"RKVST_APPREG_CLIENT\")\n",
     "print(\"client_id\", client_id)\n",
     "\n",
-    "client_secret = getenv(\"TEST_CLIENT_SECRET\")\n",
+    "client_secret = getenv(\"RKVST_APPREG_SECRET\")\n",
     "print(\"client_secret\", client_secret)"
    ]
   },
@@ -173,9 +173,9 @@
     "from archivist.utils import get_auth\n",
     "\n",
     "auth = get_auth(\n",
-    "    auth_token=getenv(\"TEST_AUTHTOKEN\"),\n",
-    "    client_id=getenv(\"TEST_CLIENT_ID\"),\n",
-    "    client_secret=getenv(\"TEST_CLIENT_SECRET\"),\n",
+    "    auth_token=getenv(\"RKVST_AUTHTOKEN\"),\n",
+    "    client_id=getenv(\"RKVST_APPREG_CLIENT\"),\n",
+    "    client_secret=getenv(\"RKVST_APPREG_SECRET\"),\n",
     ")\n",
     "with Archivist(URL, auth) as arch:\n",
     "    print(arch)"

--- a/docs/logger.rst
+++ b/docs/logger.rst
@@ -12,8 +12,8 @@ The first (optional) call from the archivist package is to set the logger.
     from archivist.archivist import Archivist
 
     set_logger("DEBUG")
-    client_id = getenv("ARCHIVIST_CLIENT_ID")
-    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILENAME")
+    client_id = getenv("RKVST_APPREG_CLIENT")
+    client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
     with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
         client_secret = tokenfile.read().strip()
 

--- a/docs/runner/components/assets_create.rst
+++ b/docs/runner/components/assets_create.rst
@@ -12,7 +12,7 @@ The :code:`arc_namespace` (for the asset) and the :code:`namespace` (for the loc
 to distinguish between assets and locations created between runs of the story.
 
 Usually these field values are derived from an environment variable 
-:code:`ARCHIVIST_NAMESPACE` (default value is :code:`namespace`).
+:code:`RKVST_NAMESPACE` (default value is :code:`namespace`).
 
 The optional :code:`confirm: true` entry means that the step will wait for the asset to be completely created before moving on to the next step.
 

--- a/docs/runner/components/assets_create_if_not_exists.rst
+++ b/docs/runner/components/assets_create_if_not_exists.rst
@@ -17,7 +17,7 @@ The :code:`arc_namespace` (for the asset) and the :code:`namespace` (for the loc
 to distinguish between assets and locations created between runs of the story.
 
 Usually these field values are derived from an environment variable 
-:code:`ARCHIVIST_NAMESPACE` (default value is :code:`namespace`).
+:code:`RKVST_NAMESPACE` (default value is :code:`namespace`).
 
 :code:`confirm: true` means that the step will wait for the asset to be completely created before moving on to the next step.
 

--- a/examples/access_policies_filter.py
+++ b/examples/access_policies_filter.py
@@ -26,11 +26,11 @@ def main():
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     auth = get_auth(
-        auth_token=getenv("ARCHIVIST_AUTHTOKEN"),
-        auth_token_filename=getenv("ARCHIVIST_AUTHTOKEN_FILENAME"),
-        client_id=getenv("ARCHIVIST_CLIENT_ID"),
-        client_secret=getenv("ARCHIVIST_CLIENT_SECRET"),
-        client_secret_filename=getenv("ARCHIVIST_CLIENT_SECRET_FILENAME"),
+        auth_token=getenv("RKVST_AUTHTOKEN"),
+        auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+        client_id=getenv("RKVST_APPREG_CLIENT"),
+        client_secret=getenv("RKVST_APPREG_SECRET"),
+        client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
     )
 
     # Initialize connection to Archivist

--- a/examples/access_policy_create.py
+++ b/examples/access_policy_create.py
@@ -29,8 +29,8 @@ def main():
     # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
-    client_id = getenv("ARCHIVIST_CLIENT_ID")
-    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    client_id = getenv("RKVST_APPREG_CLIENT")
+    client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
     with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
         client_secret = tokenfile.read().strip()
 

--- a/examples/compliance_policies_since.py
+++ b/examples/compliance_policies_since.py
@@ -32,11 +32,11 @@ def get_archivist():
     # the client_secret_file environment variable.
     #
     auth = get_auth(
-        auth_token=getenv("ARCHIVIST_AUTHTOKEN"),
-        auth_token_filename=getenv("ARCHIVIST_AUTHTOKEN_FILENAME"),
-        client_id=getenv("ARCHIVIST_CLIENT_ID"),
-        client_secret=getenv("ARCHIVIST_CLIENT_SECRET"),
-        client_secret_filename=getenv("ARCHIVIST_CLIENT_SECRET_FILENAME"),
+        auth_token=getenv("RKVST_AUTHTOKEN"),
+        auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+        client_id=getenv("RKVST_APPREG_CLIENT"),
+        client_secret=getenv("RKVST_APPREG_SECRET"),
+        client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
     )
 
     # Initialize connection to Archivist

--- a/examples/create_asset.py
+++ b/examples/create_asset.py
@@ -94,11 +94,11 @@ def main():
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
     auth = get_auth(
-        auth_token=getenv("ARCHIVIST_AUTHTOKEN"),
-        auth_token_filename=getenv("ARCHIVIST_AUTHTOKEN_FILENAME"),
-        client_id=getenv("ARCHIVIST_CLIENT_ID"),
-        client_secret=getenv("ARCHIVIST_CLIENT_SECRET"),
-        client_secret_filename=getenv("ARCHIVIST_CLIENT_SECRET_FILENAME"),
+        auth_token=getenv("RKVST_AUTHTOKEN"),
+        auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+        client_id=getenv("RKVST_APPREG_CLIENT"),
+        client_secret=getenv("RKVST_APPREG_SECRET"),
+        client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
     )
 
     # Initialize connection to Archivist. max_time is the time to wait for confirmation

--- a/examples/create_event.py
+++ b/examples/create_event.py
@@ -146,8 +146,8 @@ def main():
     # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
-    client_id = getenv("ARCHIVIST_CLIENT_ID")
-    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    client_id = getenv("RKVST_APPREG_CLIENT")
+    client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
     with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
         client_secret = tokenfile.read().strip()
 

--- a/examples/filter_assets.py
+++ b/examples/filter_assets.py
@@ -29,8 +29,8 @@ def main():
     # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
-    client_id = getenv("ARCHIVIST_CLIENT_ID")
-    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    client_id = getenv("RKVST_APPREG_CLIENT")
+    client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
     with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
         client_secret = tokenfile.read().strip()
 

--- a/examples/filter_events.py
+++ b/examples/filter_events.py
@@ -28,8 +28,8 @@ def main():
     # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
-    client_id = getenv("ARCHIVIST_CLIENT_ID")
-    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    client_id = getenv("RKVST_APPREG_CLIENT")
+    client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
     with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
         client_secret = tokenfile.read().strip()
 

--- a/examples/get_asset.py
+++ b/examples/get_asset.py
@@ -27,8 +27,8 @@ def main():
     # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
-    client_id = getenv("ARCHIVIST_CLIENT_ID")
-    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    client_id = getenv("RKVST_APPREG_CLIENT")
+    client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
     with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
         client_secret = tokenfile.read().strip()
 

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -24,7 +24,7 @@ def run(arch: Archivist, args):
     # if namespace is specified on the commandline then override any environment
     # setting...
     if args.namespace:
-        environ["ARCHIVIST_NAMESPACE"] = args.namespace
+        environ["RKVST_NAMESPACE"] = args.namespace
 
     with open(args.yamlfile, "r", encoding="utf-8") as y:
         arch.runner(parse_config(data=y))

--- a/examples/sbom_release.py
+++ b/examples/sbom_release.py
@@ -91,11 +91,11 @@ def main():
     rkvst_url = getenv("RKVST_URL")
 
     auth = get_auth(
-        auth_token=getenv("AUTHTOKEN"),
-        auth_token_filename=getenv("AUTHTOKEN_FILENAME"),
-        client_id=getenv("CLIENT_ID"),
-        client_secret=getenv("CLIENT_SECRET"),
-        client_secret_filename=getenv("CLIENT_SECRET_FILENAME"),
+        auth_token=getenv("RKVST_AUTHTOKEN"),
+        auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+        client_id=getenv("RKVST_APPREG_CLIENT"),
+        client_secret=getenv("RKVST_APPREG_SECRET"),
+        client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
     )
 
     with Archivist(rkvst_url, auth, verify=False, max_time=300) as arch:

--- a/examples/scan_test.py
+++ b/examples/scan_test.py
@@ -128,14 +128,14 @@ def main():
     main entry point
     """
     auth = get_auth(
-        auth_token=getenv("TEST_AUTHTOKEN"),
-        auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-        client_id=getenv("TEST_CLIENT_ID"),
-        client_secret=getenv("TEST_CLIENT_SECRET"),
-        client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+        auth_token=getenv("RKVST_AUTHTOKEN"),
+        auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+        client_id=getenv("RKVST_APPREG_CLIENT"),
+        client_secret=getenv("RKVST_APPREG_SECRET"),
+        client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
     )
 
-    with Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False, max_time=300) as arch:
+    with Archivist(getenv("RKVST_URL"), auth, verify=False, max_time=300) as arch:
 
         print("##[group]Today")
         today = date.today()

--- a/examples/sharing_asset.py
+++ b/examples/sharing_asset.py
@@ -63,7 +63,7 @@ def create_archivist(label):
     # could indicate different users in the same organization or membership of different
     # organiastions.
     auth = get_auth(
-        auth_token=getenv(f"ARCHIVIST_AUTHTOKEN_{label}"),
+        auth_token=getenv(f"RKVST_AUTHTOKEN_{label}"),
     )
     # Initialize connection to Archivist. max_time is the time to wait for confirmation
     # of an asset or event creation - the default is 1200 seconds but one can optionally

--- a/examples/subject_create.py
+++ b/examples/subject_create.py
@@ -28,8 +28,8 @@ def main():
     # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
-    client_id = getenv("ARCHIVIST_CLIENT_ID")
-    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    client_id = getenv("RKVST_APPREG_CLIENT")
+    client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
     with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
         client_secret = tokenfile.read().strip()
 

--- a/examples/subjects_filter.py
+++ b/examples/subjects_filter.py
@@ -22,8 +22,8 @@ def main():
     # client id is an environment variable. client_secret is stored in a file in a
     # directory that has 0700 permissions. The location of this file is set in
     # the client_secret_file environment variable.
-    client_id = getenv("ARCHIVIST_CLIENT_ID")
-    client_secret_file = getenv("ARCHIVIST_CLIENT_SECRET_FILE")
+    client_id = getenv("RKVST_APPREG_CLIENT")
+    client_secret_file = getenv("RKVST_APPREG_SECRET_FILENAME")
     with open(client_secret_file, mode="r", encoding="utf-8") as tokenfile:
         client_secret = tokenfile.read().strip()
 

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -105,13 +105,13 @@ class TestAccessPoliciesBase(TestCase):
 
     def setUp(self):
         auth = get_auth(
-            auth_token=getenv("TEST_AUTHTOKEN"),
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret=getenv("TEST_CLIENT_SECRET"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token=getenv("RKVST_AUTHTOKEN"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret=getenv("RKVST_APPREG_SECRET"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)
+        self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False)
 
         # these are for access_policies
         self.ac_props = deepcopy(PROPS)
@@ -278,8 +278,8 @@ TESTDATA = [
 
 
 @skipIf(
-    getenv("TEST_AUTHTOKEN_FILENAME_2") is None,
-    "cannot run test as TEST_AUTHTOKEN_FILENAME_2 is not set",
+    getenv("RKVST_AUTHTOKEN_FILENAME_2") is None,
+    "cannot run test as RKVST_AUTHTOKEN_FILENAME_2 is not set",
 )
 class TestAccessPoliciesShare(TestAccessPoliciesBase):
     """
@@ -290,9 +290,9 @@ class TestAccessPoliciesShare(TestAccessPoliciesBase):
 
     def setUp(self):
         super().setUp()
-        with open(getenv("TEST_AUTHTOKEN_FILENAME_2"), encoding="utf-8") as fd:
+        with open(getenv("RKVST_AUTHTOKEN_FILENAME_2"), encoding="utf-8") as fd:
             auth_2 = fd.read().strip()
-        self.arch_2 = Archivist(getenv("TEST_ARCHIVIST"), auth_2, verify=False)
+        self.arch_2 = Archivist(getenv("RKVST_URL"), auth_2, verify=False)
 
         # creates reciprocal subjects for arch 1 and arch 2.
         # subject 1 contains details of subject 2 to be shared

--- a/functests/execapplications.py
+++ b/functests/execapplications.py
@@ -31,8 +31,8 @@ ATTRS = {
     "some_custom_attribute": "value",
 }
 
-if getenv("TEST_DEBUG") is not None:
-    set_logger(getenv("TEST_DEBUG"))
+if getenv("RKVST_DEBUG") is not None:
+    set_logger(getenv("RKVST_DEBUG"))
 
 
 class TestApplications(TestCase):
@@ -44,13 +44,13 @@ class TestApplications(TestCase):
 
     def setUp(self):
         auth = get_auth(
-            auth_token=getenv("TEST_AUTHTOKEN"),
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret=getenv("TEST_CLIENT_SECRET"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token=getenv("RKVST_AUTHTOKEN"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret=getenv("RKVST_APPREG_SECRET"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)
+        self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False)
         self.display_name = f"{DISPLAY_NAME} {uuid4()}"
 
     def tearDown(self):
@@ -201,8 +201,8 @@ class TestApplications(TestCase):
             )
 
     @skipIf(
-        getenv("TEST_REFRESH_TOKEN") is None,
-        "cannot run test as TEST_REFRESH_TOKEN is not set",
+        getenv("RKVST_REFRESH_TOKEN") is None,
+        "cannot run test as RKVST_REFRESH_TOKEN is not set",
     )
     def test_archivist_token(self):
         """
@@ -224,7 +224,7 @@ class TestApplications(TestCase):
         # archivist using app registration
         print("New Arch")
         with Archivist(
-            getenv("TEST_ARCHIVIST"),
+            getenv("RKVST_URL"),
             (application["client_id"], application["credentials"][0]["secret"]),
             verify=False,
         ) as new_arch:

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -19,8 +19,8 @@ from archivist.utils import get_auth
 # pylint: disable=unused-variable
 
 
-if getenv("TEST_DEBUG") is not None:
-    set_logger(getenv("TEST_DEBUG"))
+if getenv("RKVST_DEBUG") is not None:
+    set_logger(getenv("RKVST_DEBUG"))
 
 ATTRS = {
     "arc_firmware_version": "1.0",
@@ -72,15 +72,13 @@ class TestAssetCreate(TestCase):
 
     def setUp(self):
         auth = get_auth(
-            auth_token=getenv("TEST_AUTHTOKEN"),
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret=getenv("TEST_CLIENT_SECRET"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token=getenv("RKVST_AUTHTOKEN"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret=getenv("RKVST_APPREG_SECRET"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(
-            getenv("TEST_ARCHIVIST"), auth, verify=False, max_time=600
-        )
+        self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False, max_time=600)
         self.attrs = deepcopy(ATTRS)
         self.traffic_light = deepcopy(ATTRS)
         self.traffic_light["arc_display_type"] = "Traffic light with violation camera"
@@ -237,15 +235,13 @@ class TestAssetCreateIfNotExists(TestCase):
 
     def setUp(self):
         auth = get_auth(
-            auth_token=getenv("TEST_AUTHTOKEN"),
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret=getenv("TEST_CLIENT_SECRET"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token=getenv("RKVST_AUTHTOKEN"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret=getenv("RKVST_APPREG_SECRET"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(
-            getenv("TEST_ARCHIVIST"), auth, verify=False, max_time=600
-        )
+        self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False, max_time=600)
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execattachments.py
+++ b/functests/execattachments.py
@@ -14,8 +14,8 @@ from archivist.logger import set_logger
 from archivist.utils import get_auth, get_url
 
 
-if getenv("TEST_DEBUG") is not None:
-    set_logger(getenv("TEST_DEBUG"))
+if getenv("RKVST_DEBUG") is not None:
+    set_logger(getenv("RKVST_DEBUG"))
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
@@ -27,53 +27,53 @@ class TestAttachmentsCreate(TestCase):
     Test Archivist Attachment Create method
     """
 
-    TEST_DOCX_PATH = "functests/test_resources/loremipsum.docx"
-    TEST_DOCX_DOWNLOAD_PATH = "functests/test_resources/downloaded_loremipsum.docx"
-    TEST_IMAGE_PATH = "functests/test_resources/rkvst_logo.png"
-    TEST_IMAGE_DOWNLOAD_PATH = "functests/test_resources/downloaded_image.jpg"
+    RKVST_DOCX_PATH = "functests/test_resources/loremipsum.docx"
+    RKVST_DOCX_DOWNLOAD_PATH = "functests/test_resources/downloaded_loremipsum.docx"
+    RKVST_IMAGE_PATH = "functests/test_resources/rkvst_logo.png"
+    RKVST_IMAGE_DOWNLOAD_PATH = "functests/test_resources/downloaded_image.jpg"
 
     def setUp(self):
         auth = get_auth(
-            auth_token=getenv("TEST_AUTHTOKEN"),
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret=getenv("TEST_CLIENT_SECRET"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token=getenv("RKVST_AUTHTOKEN"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret=getenv("RKVST_APPREG_SECRET"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)
+        self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False)
         self.file_uuid: str = ""
 
         with suppress(FileNotFoundError):
-            remove(self.TEST_IMAGE_DOWNLOAD_PATH)
+            remove(self.RKVST_IMAGE_DOWNLOAD_PATH)
 
         with suppress(FileNotFoundError):
-            remove(self.TEST_DOCX_DOWNLOAD_PATH)
+            remove(self.RKVST_DOCX_DOWNLOAD_PATH)
 
     def tearDown(self) -> None:
         """Remove the downloaded image for subsequent test runs"""
         self.arch.close()
         with suppress(FileNotFoundError):
-            remove(self.TEST_IMAGE_DOWNLOAD_PATH)
+            remove(self.RKVST_IMAGE_DOWNLOAD_PATH)
 
         with suppress(FileNotFoundError):
-            remove(self.TEST_DOCX_DOWNLOAD_PATH)
+            remove(self.RKVST_DOCX_DOWNLOAD_PATH)
 
     def test_attachment_upload_and_download(self):
         """
         Test file upload through the SDK
         Test file download through the SDK
         """
-        with open(self.TEST_IMAGE_PATH, "rb") as fd:
+        with open(self.RKVST_IMAGE_PATH, "rb") as fd:
             attachment = self.arch.attachments.upload(fd)
             file_uuid = attachment["identity"]
 
-        with open(self.TEST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
+        with open(self.RKVST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
             attachment = self.arch.attachments.download(file_uuid, fd)
 
         # Check the downloaded file is identical to the one that was uploaded
         clear_cache()
         self.assertTrue(
-            cmp(self.TEST_IMAGE_PATH, self.TEST_IMAGE_DOWNLOAD_PATH, shallow=False)
+            cmp(self.RKVST_IMAGE_PATH, self.RKVST_IMAGE_DOWNLOAD_PATH, shallow=False)
         )
 
     def test_attachment_upload_and_download_docx(self):
@@ -81,7 +81,7 @@ class TestAttachmentsCreate(TestCase):
         Test file upload through the SDK
         Test file download through the SDK
         """
-        with open(self.TEST_DOCX_PATH, "rb") as fd:
+        with open(self.RKVST_DOCX_PATH, "rb") as fd:
             attachment = self.arch.attachments.upload(fd)
             file_uuid = attachment["identity"]
 
@@ -93,7 +93,7 @@ class TestAttachmentsCreate(TestCase):
             msg="UPLOAD incorrect mimetype",
         )
 
-        with open(self.TEST_DOCX_DOWNLOAD_PATH, "wb") as fd:
+        with open(self.RKVST_DOCX_DOWNLOAD_PATH, "wb") as fd:
             attachment = self.arch.attachments.download(file_uuid, fd)
 
         print("attachment", attachment.headers)
@@ -111,15 +111,15 @@ class TestAttachmentsCreate(TestCase):
         )
 
     @skipIf(
-        getenv("TEST_BLOB_IDENTITY") is None,
-        "cannot run test as TEST_BLOB_IDENTITY is not set",
+        getenv("RKVST_BLOB_IDENTITY") is None,
+        "cannot run test as RKVST_BLOB_IDENTITY is not set",
     )
     def test_attachment_info(self):
         """
         Test file info through the SDK
         Test file download through the SDK
         """
-        file_uuid = getenv("TEST_BLOB_IDENTITY")
+        file_uuid = getenv("RKVST_BLOB_IDENTITY")
         info = self.arch.attachments.info(file_uuid)
         print("attachment info", json_dumps(info, indent=4))
 
@@ -128,11 +128,11 @@ class TestAttachmentsCreate(TestCase):
         Test file upload through the SDK
         Test file download through the SDK
         """
-        with open(self.TEST_IMAGE_PATH, "rb") as fd:
+        with open(self.RKVST_IMAGE_PATH, "rb") as fd:
             attachment = self.arch.attachments.upload(fd)
             file_uuid = attachment["identity"]
 
-        with open(self.TEST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
+        with open(self.RKVST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
             attachment = self.arch.attachments.download(
                 file_uuid, fd, params={"allow_insecure": "true"}
             )
@@ -140,7 +140,7 @@ class TestAttachmentsCreate(TestCase):
         # Check the downloaded file is identical to the one that was uploaded
         clear_cache()
         self.assertTrue(
-            cmp(self.TEST_IMAGE_PATH, self.TEST_IMAGE_DOWNLOAD_PATH, shallow=False)
+            cmp(self.RKVST_IMAGE_PATH, self.RKVST_IMAGE_DOWNLOAD_PATH, shallow=False)
         )
 
     def test_attachment_upload_and_download_strict(self):
@@ -148,11 +148,11 @@ class TestAttachmentsCreate(TestCase):
         Test file upload through the SDK
         Test file download through the SDK
         """
-        with open(self.TEST_IMAGE_PATH, "rb") as fd:
+        with open(self.RKVST_IMAGE_PATH, "rb") as fd:
             attachment = self.arch.attachments.upload(fd)
             file_uuid = attachment["identity"]
 
-        with open(self.TEST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
+        with open(self.RKVST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
             with self.assertRaises(ArchivistBadRequestError):
                 attachment = self.arch.attachments.download(
                     file_uuid, fd, params={"strict": "true"}
@@ -166,32 +166,32 @@ class TestAttachmentstMalware(TestCase):
 
     # we dont want to actually store these files in our repo so download
     # every time.
-    TEST_MALWARE1 = "https://secure.eicar.org/eicar.com"
-    TEST_MALWARE2 = "https://secure.eicar.org/eicar.com.txt"
-    TEST_MALWARE3 = "https://secure.eicar.org/eicar.com.zip"
-    TEST_MALWARE4 = "https://secure.eicar.org/eicarcom2.zip"
+    RKVST_MALWARE1 = "https://secure.eicar.org/eicar.com"
+    RKVST_MALWARE2 = "https://secure.eicar.org/eicar.com.txt"
+    RKVST_MALWARE3 = "https://secure.eicar.org/eicar.com.zip"
+    RKVST_MALWARE4 = "https://secure.eicar.org/eicarcom2.zip"
 
     @classmethod
     def setUpClass(cls):
         cls.malware1 = BytesIO()
-        get_url(cls.TEST_MALWARE1, cls.malware1)
+        get_url(cls.RKVST_MALWARE1, cls.malware1)
 
         cls.malware2 = BytesIO()
-        get_url(cls.TEST_MALWARE2, cls.malware2)
+        get_url(cls.RKVST_MALWARE2, cls.malware2)
 
         cls.malware3 = BytesIO()
-        get_url(cls.TEST_MALWARE3, cls.malware3)
+        get_url(cls.RKVST_MALWARE3, cls.malware3)
 
         cls.malware4 = BytesIO()
-        get_url(cls.TEST_MALWARE4, cls.malware4)
+        get_url(cls.RKVST_MALWARE4, cls.malware4)
 
     def setUp(self):
         auth = get_auth(
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)
+        self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False)
 
     def tearDown(self):
         self.arch.close()

--- a/functests/execcompliance_policies.py
+++ b/functests/execcompliance_policies.py
@@ -24,8 +24,8 @@ from archivist.utils import get_auth
 
 from archivist import logger
 
-if getenv("TEST_DEBUG") is not None:
-    logger.set_logger(getenv("TEST_DEBUG"))
+if getenv("RKVST_DEBUG") is not None:
+    logger.set_logger(getenv("RKVST_DEBUG"))
 else:
     logger.set_logger("INFO")
 
@@ -94,12 +94,12 @@ class TestCompliancePoliciesBase(TestCase):
 
     def setUp(self):
         auth = get_auth(
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret=getenv("TEST_CLIENT_SECRET"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret=getenv("RKVST_APPREG_SECRET"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)
+        self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False)
         print()
 
     def tearDown(self):

--- a/functests/execpublicassets.py
+++ b/functests/execpublicassets.py
@@ -20,8 +20,8 @@ from archivist.utils import get_auth
 # pylint: disable=unused-variable
 
 
-if getenv("TEST_DEBUG") is not None:
-    set_logger(getenv("TEST_DEBUG"))
+if getenv("RKVST_DEBUG") is not None:
+    set_logger(getenv("RKVST_DEBUG"))
 
 ATTRS = {
     "arc_firmware_version": "1.0",
@@ -74,13 +74,13 @@ class TestPublicAssetCreate(TestCase):
 
     def setUp(self):
         auth = get_auth(
-            auth_token=getenv("TEST_AUTHTOKEN"),
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret=getenv("TEST_CLIENT_SECRET"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token=getenv("RKVST_AUTHTOKEN"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret=getenv("RKVST_APPREG_SECRET"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.url = getenv("TEST_ARCHIVIST")
+        self.url = getenv("RKVST_URL")
         self.arch = Archivist(self.url, auth, verify=False, max_time=600)
         self.attrs = deepcopy(ATTRS)
         self.traffic_light = deepcopy(ATTRS)

--- a/functests/execrunner.py
+++ b/functests/execrunner.py
@@ -18,8 +18,8 @@ from archivist.utils import get_auth
 
 from archivist import logger
 
-if getenv("TEST_DEBUG") is not None:
-    logger.set_logger(getenv("TEST_DEBUG"))
+if getenv("RKVST_DEBUG") is not None:
+    logger.set_logger(getenv("RKVST_DEBUG"))
 else:
     logger.set_logger("INFO")
 
@@ -35,14 +35,12 @@ class TestRunner(TestCase):
 
     def setUp(self):
         auth = get_auth(
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret=getenv("TEST_CLIENT_SECRET"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret=getenv("RKVST_APPREG_SECRET"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(
-            getenv("TEST_ARCHIVIST"), auth, verify=False, max_time=300
-        )
+        self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False, max_time=300)
 
     def tearDown(self):
         self.arch.close()
@@ -51,7 +49,7 @@ class TestRunner(TestCase):
         """
         Test runner with dynamic tolerance story
 
-        uses ARCHIVIST_NAMESPACE to set namespace value
+        uses RKVST_NAMESPACE to set namespace value
 
         run_steps is used so that exceptions are shown
         """
@@ -72,7 +70,7 @@ class TestRunner(TestCase):
         """
         Test runner with synsation story
 
-        uses ARCHIVIST_NAMESPACE to set namespace value
+        uses RKVST_NAMESPACE to set namespace value
 
         run_steps is used so that exceptions are shown
         """
@@ -113,7 +111,7 @@ class TestRunner(TestCase):
         """
         Test runner with richness story
 
-        uses ARCHIVIST_NAMESPACE to set namespace value
+        uses RKVST_NAMESPACE to set namespace value
 
         run_steps is used so that exceptions are shown
         """
@@ -135,7 +133,7 @@ class TestRunner(TestCase):
         """
         Test runner with door_entry story
 
-        uses ARCHIVIST_NAMESPACE to set namespace value
+        uses RKVST_NAMESPACE to set namespace value
 
         run_steps is used so that exceptions are shown
         """
@@ -171,7 +169,7 @@ class TestRunner(TestCase):
         """
         Test runner with wipp story
 
-        uses ARCHIVIST_NAMESPACE to set namespace value
+        uses RKVST_NAMESPACE to set namespace value
 
         run_steps is used so that exceptions are shown
         """

--- a/functests/execsubjects.py
+++ b/functests/execsubjects.py
@@ -15,8 +15,8 @@ from archivist.utils import get_auth
 
 from archivist import logger
 
-if getenv("TEST_DEBUG") is not None:
-    logger.set_logger(getenv("TEST_DEBUG"))
+if getenv("RKVST_DEBUG") is not None:
+    logger.set_logger(getenv("RKVST_DEBUG"))
 else:
     logger.set_logger("INFO")
 
@@ -57,12 +57,12 @@ class TestSubjects(TestCase):
 
     def setUp(self):
         auth = get_auth(
-            auth_token_filename=getenv("TEST_AUTHTOKEN_FILENAME"),
-            client_id=getenv("TEST_CLIENT_ID"),
-            client_secret=getenv("TEST_CLIENT_SECRET"),
-            client_secret_filename=getenv("TEST_CLIENT_SECRET_FILENAME"),
+            auth_token_filename=getenv("RKVST_AUTHTOKEN_FILENAME"),
+            client_id=getenv("RKVST_APPREG_CLIENT"),
+            client_secret=getenv("RKVST_APPREG_SECRET"),
+            client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
-        self.arch = Archivist(getenv("TEST_ARCHIVIST"), auth, verify=False)
+        self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False)
         self.display_name = f"{DISPLAY_NAME} {uuid4()}"
 
     def tearDown(self):

--- a/functests/test_resources/door_entry_story.yaml
+++ b/functests/test_resources/door_entry_story.yaml
@@ -22,7 +22,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: RKVST Paris Front Door
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-j1-01
@@ -38,7 +38,7 @@ steps:
       latitude: 48.8339211
       longitude: 2.371345
       attributes:
-        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+        namespace: !ENV ${RKVST_NAMESPACE:namespace}
         address: 5 Parvis Alan Turing, 75013 Paris, France
         wavestone_ext: managed
     attachments:
@@ -59,7 +59,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: City Hall Paris Front Door
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-01
@@ -75,7 +75,7 @@ steps:
       latitude: 48.856389
       longitude: 2.352222
       attributes:
-        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+        namespace: !ENV ${RKVST_NAMESPACE:namespace}
         address: Place de l'Hôtel de Ville, 75004 Paris, France
         wavestone_ext: managed
       attachments:
@@ -97,7 +97,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Courts of Justice Paris Front Door
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-02
@@ -113,7 +113,7 @@ steps:
       latitude: 48.855722
       longitude: 2.345051
       attributes:
-        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+        namespace: !ENV ${RKVST_NAMESPACE:namespace}
         address: 10 Boulevard du Palais, 75001 Paris, France
         wavestone_ext: managed
     attachments:
@@ -134,7 +134,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Bastille Paris Front Door
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-03
@@ -150,7 +150,7 @@ steps:
       latitude: 48.85333
       longitude: 2.36917
       attributes:
-        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+        namespace: !ENV ${RKVST_NAMESPACE:namespace}
         address: Place de la Bastille, 75011 Paris, France
         wavestone_ext: managed
     attachments:
@@ -171,7 +171,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Gare du Nord Apartments Paris Front Door
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-04
@@ -187,7 +187,7 @@ steps:
       latitude: 48.8809
       longitude: 2.3553
       attributes:
-        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+        namespace: !ENV ${RKVST_NAMESPACE:namespace}
         address: 18 Rue de Dunkerque, 75010 Paris, France
         wavestone_ext: managed
     attachments:
@@ -208,7 +208,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Gare du Nord Apartments Paris Side Door
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: door
       arc_firmware_version: "1.0"
       arc_serial_number: das-x4-05
@@ -224,7 +224,7 @@ steps:
       latitude: 48.8809
       longitude: 2.3553
       attributes:
-        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+        namespace: !ENV ${RKVST_NAMESPACE:namespace}
         address: 18 Rue de Dunkerque, 75010 Paris, France
         wavestone_ext: managed
     attachments:
@@ -252,7 +252,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Access Card 1
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: card
       arc_serial_number: sc-x5-1
       arc_description: Electronic door Access Card 1
@@ -272,7 +272,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Access Card 2
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: card
       arc_serial_number: sc-x5-2
       arc_description: Electronic door Access Card 2
@@ -291,7 +291,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Access Card 3
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_serial_number: sc-x5-3
       arc_description: Electronic door Access Card 3
     confirm: true
@@ -309,7 +309,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Access Card 4
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: card
       arc_serial_number: sc-x5-4
       arc_description: Electronic door Access Card 4
@@ -328,7 +328,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Access Card 5
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: card
       arc_serial_number: sc-x5-5
       arc_description: Electronic door Access Card 5
@@ -389,7 +389,7 @@ steps:
       print_response: true
     attrs:
       arc_display_type: door
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
 
   - step:
       action: ASSETS_LIST
@@ -397,7 +397,7 @@ steps:
       print_response: true
     attrs:
       arc_display_type: card
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
 
   - step:
       action: EVENTS_LIST

--- a/functests/test_resources/dynamic_tolerance_story.yaml
+++ b/functests/test_resources/dynamic_tolerance_story.yaml
@@ -19,7 +19,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: ev pump 1
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       ev_pump: "true"
     confirm: true
 

--- a/functests/test_resources/richness_story.yaml
+++ b/functests/test_resources/richness_story.yaml
@@ -16,7 +16,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: radiation bag 1
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       radioactive: "true"
       radiation_level: "0"
       weight: "0"
@@ -31,7 +31,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: radiation bag 2
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       radioactive: "true"
       radiation_level: "0"
       weight: "0"
@@ -46,7 +46,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: radiation bag 3
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       radioactive: "true"
       radiation_level: "0"
       weight: "0"

--- a/functests/test_resources/sbom_story.yaml
+++ b/functests/test_resources/sbom_story.yaml
@@ -23,7 +23,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: ACME Corporation Detector SAAS
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: Software Package
       arc_description: Software Bill of Materials for Detector SAAS
       acme_sbom_license: www.gnu.org/licenses/gpl.txt
@@ -94,7 +94,7 @@ steps:
       print_response: true
     attrs:
       arc_display_type: Software Package
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
 
   - step:
       action: EVENTS_LIST
@@ -105,4 +105,4 @@ steps:
       confirmation_status: CONFIRMED
     attrs:
       arc_display_type: Software Package Release
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}

--- a/functests/test_resources/synsation_story.yaml.j2
+++ b/functests/test_resources/synsation_story.yaml.j2
@@ -23,7 +23,7 @@ steps:
     latitude: {{ location.latitude }}
     longitude: {{ location.longitude }}
     attributes:
-      namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
+      namespace: "{{ env['RKVST_NAMESPACE'] or 'namespace' }}"
       address: {{ location.attributes.address }}
       facility_type: {{ location.attributes.facility_type }}
       reception_email: {{ location.attributes.reception_email }}
@@ -34,14 +34,14 @@ steps:
       description: Count locations in namespace
       print_response: true
     attrs:
-      namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
+      namespace: "{{ env['RKVST_NAMESPACE'] or 'namespace' }}"
 
   - step:
       action: LOCATIONS_LIST
       description: List locations in namespace
       print_response: true
     attrs:
-      namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
+      namespace: "{{ env['RKVST_NAMESPACE'] or 'namespace' }}"
 
   {% for asset in assets %} 
   - step:
@@ -58,7 +58,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: {{ asset.type }} in {{ asset.location_label }}
-      arc_namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
+      arc_namespace: "{{ env['RKVST_NAMESPACE'] or 'namespace' }}"
       arc_display_type: {{ asset.type }}
       arc_firmware_version: {{ asset.firmware_version }}
       arc_serial_number: {{ asset.serial_number }}
@@ -75,7 +75,7 @@ steps:
       description: Wait for all assets to be confirmed
       print_response: true
     attrs:
-      arc_namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
+      arc_namespace: "{{ env['RKVST_NAMESPACE'] or 'namespace' }}"
 
   - step:
       action: ASSETS_LIST
@@ -83,7 +83,7 @@ steps:
       print_response: true
     attrs:
       arc_display_type: printer
-      arc_namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
+      arc_namespace: "{{ env['RKVST_NAMESPACE'] or 'namespace' }}"
 
   - step:
       action: ASSETS_LIST
@@ -91,7 +91,7 @@ steps:
       print_response: true
     attrs:
       arc_display_type: coffee machine
-      arc_namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
+      arc_namespace: "{{ env['RKVST_NAMESPACE'] or 'namespace' }}"
 
   - step:
       action: ASSETS_LIST
@@ -99,5 +99,5 @@ steps:
       print_response: true
     attrs:
       arc_display_type: security camera
-      arc_namespace: "{{ env['ARCHIVIST_NAMESPACE'] or 'namespace' }}"
+      arc_namespace: "{{ env['RKVST_NAMESPACE'] or 'namespace' }}"
 

--- a/functests/test_resources/wipp_story.yaml
+++ b/functests/test_resources/wipp_story.yaml
@@ -18,7 +18,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Drum 1
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: drum
       arc_description: Standard non-POC 55 gallon drum No. 1
       wipp_capacity: "55"
@@ -41,7 +41,7 @@ steps:
       - Attachments
     attributes:
       arc_display_name: Cask 1
-      arc_namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+      arc_namespace: !ENV ${RKVST_NAMESPACE:namespace}
       arc_display_type: cask
       arc_description: NRC certified type-B road shipping container, capacity 3 x 55-gallon drum
       wipp_capacity: "3"
@@ -238,7 +238,7 @@ steps:
       latitude: 33.592177
       longitude: -84.406064
       attributes:
-        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+        namespace: !ENV ${RKVST_NAMESPACE:namespace}
     attachments:
       - filename: functests/test_resources/wipp/truck_departure.jpg
         content_type: image/jpg
@@ -268,7 +268,7 @@ steps:
       latitude: 33.592177
       longitude: -86.248379
       attributes:
-        namespace: !ENV ${ARCHIVIST_NAMESPACE:namespace}
+        namespace: !ENV ${RKVST_NAMESPACE:namespace}
     attachments:
       - filename: functests/test_resources/wipp/truck_departure.jpg
         content_type: image/jpg

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -19,17 +19,17 @@ docker run \
     -u $(id -u):$(id -g) \
     -e FUNCTEST \
     -e UNITTEST \
-    -e ARCHIVIST_NAMESPACE \
-    -e TEST_ARCHIVIST \
-    -e TEST_AUTHTOKEN \
-    -e TEST_AUTHTOKEN_FILENAME \
-    -e TEST_AUTHTOKEN_FILENAME_2 \
-    -e TEST_BLOB_IDENTITY \
-    -e TEST_CLIENT_ID \
-    -e TEST_CLIENT_SECRET \
-    -e TEST_CLIENT_SECRET_FILENAME \
-    -e TEST_DEBUG \
-    -e TEST_REFRESH_TOKEN \
+    -e RKVST_NAMESPACE \
+    -e RKVST_URL \
+    -e RKVST_AUTHTOKEN \
+    -e RKVST_AUTHTOKEN_FILENAME \
+    -e RKVST_AUTHTOKEN_FILENAME_2 \
+    -e RKVST_BLOB_IDENTITY \
+    -e RKVST_APPREG_CLIENT \
+    -e RKVST_APPREG_SECRET \
+    -e RKVST_APPREG_SECRET_FILENAME \
+    -e RKVST_DEBUG \
+    -e RKVST_REFRESH_TOKEN \
     -e GITHUB_REF \
     rkvst-python-builder \
     "$@"

--- a/scripts/functests.sh
+++ b/scripts/functests.sh
@@ -2,38 +2,38 @@
 #
 # run functional tests
 #
-if [ -z "${TEST_ARCHIVIST}" ]
+if [ -z "${RKVST_URL}" ]
 then
-    echo "TEST_ARCHIVIST is undefined"
+    echo "RKVST_URL is undefined"
     exit 1
 fi
-if [ -n "${TEST_CLIENT_ID}" ]
+if [ -n "${RKVST_APPREG_CLIENT}" ]
 then
-    if [ -n "${TEST_CLIENT_SECRET_FILENAME}" ]
+    if [ -n "${RKVST_APPREG_SECRET_FILENAME}" ]
     then
-        if [ ! -s "${TEST_CLIENT_SECRET_FILENAME}" ]
+        if [ ! -s "${RKVST_APPREG_SECRET_FILENAME}" ]
         then
-            echo "${TEST_CLIENT_SECRET_FILENAME} does not exist"
+            echo "${RKVST_APPREG_SECRET_FILENAME} does not exist"
             exit 1
         fi
-    elif [ -z "${TEST_CLIENT_SECRET}" ]
+    elif [ -z "${RKVST_APPREG_SECRET}" ]
     then
-        echo "Both TEST_CLIENT_SECRET_FILENAME"
-        echo "and TEST_CLIENT_SECRET are undefined"
+        echo "Both RKVST_APPREG_SECRET_FILENAME"
+        echo "and RKVST_APPREG_SECRET are undefined"
         exit 1
     fi
 else
-    if [ -n "${TEST_AUTHTOKEN_FILENAME}" ]
+    if [ -n "${RKVST_AUTHTOKEN_FILENAME}" ]
     then
-        if [ ! -s "${TEST_AUTHTOKEN_FILENAME}" ]
+        if [ ! -s "${RKVST_AUTHTOKEN_FILENAME}" ]
         then
-            echo "${TEST_AUTHTOKEN_FILENAME} does not exist"
+            echo "${RKVST_AUTHTOKEN_FILENAME} does not exist"
             exit 1
         fi
-    elif [ -z "${TEST_AUTHTOKEN}" ]
+    elif [ -z "${RKVST_AUTHTOKEN}" ]
     then
-        echo "Both TEST_AUTHTOKEN_FILENAME"
-        echo "and TEST_AUTHTOKEN are undefined"
+        echo "Both RKVST_AUTHTOKEN_FILENAME"
+        echo "and RKVST_AUTHTOKEN are undefined"
         exit 1
     fi
 fi

--- a/scripts/notebooks.sh
+++ b/scripts/notebooks.sh
@@ -11,6 +11,12 @@ then
     exit 0
 fi
 
+if [ ! -d rkvst-venv ]
+then
+    echo "venv does not exist - execute 'task venv'"
+    exit 1
+fi
+
 NOTEBOOKDIR=rkvst-venv/notebooks
 
 source rkvst-venv/bin/activate

--- a/scripts/venv.sh
+++ b/scripts/venv.sh
@@ -10,6 +10,12 @@ then
     exit 0
 fi
 
+if [ ! -s dist/rkvst_archivist-*.whl ]
+then
+    echo "no wheel found - execute 'task wheel'"
+    exit 1
+fi
+
 rm -rf rkvst-venv
 python3 -m venv rkvst-venv
 source rkvst-venv/bin/activate

--- a/unittests/testappidp.py
+++ b/unittests/testappidp.py
@@ -20,13 +20,13 @@ from .mock_response import MockResponse
 # pylint: disable=unused-variable
 
 SUBPATH = f"{APPIDP_SUBPATH}/{APPIDP_LABEL}/{APPIDP_TOKEN}"
-CLIENT_ID = "client_id-2f78-4fa0-9425-d59314845bc5"
-CLIENT_SECRET = "client_secret-388f5187e32d930d83"
+RKVST_APPREG_CLIENT = "client_id-2f78-4fa0-9425-d59314845bc5"
+RKVST_APPREG_SECRET = "client_secret-388f5187e32d930d83"
 ACCESS_TOKEN = "access_token-xbXATAWrEpepR7TklOxRB-yud92AsD6DGGasiEGN7MZKT0AIQ4Rw9s"
 REQUEST = {
     "grant_type": "client_credentials",
-    "client_id": CLIENT_ID,
-    "client_secret": CLIENT_SECRET,
+    "client_id": RKVST_APPREG_CLIENT,
+    "client_secret": RKVST_APPREG_SECRET,
 }
 
 RESPONSE = {
@@ -67,8 +67,8 @@ class TestAppIDP(TestCase):
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
             appidp = self.arch.appidp.token(
-                CLIENT_ID,
-                CLIENT_SECRET,
+                RKVST_APPREG_CLIENT,
+                RKVST_APPREG_SECRET,
             )
             args, kwargs = mock_post.call_args
             self.assertEqual(

--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -23,17 +23,17 @@ from .mock_response import MockResponse
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 
-CLIENT_ID = "client_id-2f78-4fa0-9425-d59314845bc5"
-CLIENT_SECRET = "client_secret-388f5187e32d930d83"
+RKVST_APPREG_CLIENT = "client_id-2f78-4fa0-9425-d59314845bc5"
+RKVST_APPREG_SECRET = "client_secret-388f5187e32d930d83"
 ACCESS_TOKEN = "access_token-xbXATAWrEpepR7TklOxRB-yud92AsD6DGGasiEGN7MZKT0AIQ4Rw9s"
 REQUEST = {
     "grant_type": "client_credentials",
-    "client_id": CLIENT_ID,
-    "client_secret": CLIENT_SECRET,
+    "client_id": RKVST_APPREG_CLIENT,
+    "client_secret": RKVST_APPREG_SECRET,
 }
 
 RESPONSE = {
@@ -167,7 +167,9 @@ class TestArchivist(TestCase):
         """
         Test archivist creation with app registration
         """
-        with Archivist("https://app.rkvst.io", (CLIENT_ID, CLIENT_SECRET)) as arch:
+        with Archivist(
+            "https://app.rkvst.io", (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET)
+        ) as arch:
             with mock.patch.object(arch.appidp, "token") as mock_token:
                 mock_token.return_value = RESPONSE
                 self.assertEqual(
@@ -190,7 +192,9 @@ class TestArchivist(TestCase):
         """
         Test archivist creation with appidp token
         """
-        with Archivist("https://app.rkvst.io", (CLIENT_ID, CLIENT_SECRET)) as arch:
+        with Archivist(
+            "https://app.rkvst.io", (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET)
+        ) as arch:
             with mock.patch.object(arch.appidp, "token") as mock_token:
                 mock_token.return_value = NONE_RESPONSE
                 with self.assertRaises(ArchivistError):

--- a/unittests/testarchivistlist.py
+++ b/unittests/testarchivistlist.py
@@ -21,8 +21,8 @@ from .testarchivist import TestArchivistMethods
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 
 class TestArchivistList(TestArchivistMethods):

--- a/unittests/testarchivistsignature.py
+++ b/unittests/testarchivistsignature.py
@@ -20,8 +20,8 @@ from .testarchivist import TestArchivistMethods
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 
 class TestArchivistSignature(TestArchivistMethods):

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -52,8 +52,8 @@ from .testassetsconstants import (
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testassetslist.py
+++ b/unittests/testassetslist.py
@@ -23,8 +23,8 @@ from .testassetsconstants import (
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testassetsread.py
+++ b/unittests/testassetsread.py
@@ -38,8 +38,8 @@ RESPONSE_BAD_PUBLICURL = {
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testassetswait.py
+++ b/unittests/testassetswait.py
@@ -28,8 +28,8 @@ from .testassetsconstants import (
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testcompliance.py
+++ b/unittests/testcompliance.py
@@ -56,8 +56,8 @@ POLICY = {
     "time_period_seconds": 10,
 }
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testnotebooks.py
+++ b/unittests/testnotebooks.py
@@ -30,16 +30,16 @@ class TestNotebooks(TestCase):
     """
 
     def setUp(self):
-        self.archivist = setenv("TEST_ARCHIVIST", "https://app.rkvst.io")
-        self.authtoken = setenv("TEST_AUTHTOKEN", "xxxxxxxxxxxxxxxxxxxx")
-        self.client_id = setenv("TEST_CLIENT_ID", "yyyyyyyyyyyyyyyyyyyy")
-        self.client_secret = setenv("TEST_CLIENT_SECRET", "zzzzzzzzzzzzzzzzzzzz")
+        self.archivist = setenv("RKVST_URL", "https://app.rkvst.io")
+        self.authtoken = setenv("RKVST_AUTHTOKEN", "xxxxxxxxxxxxxxxxxxxx")
+        self.client_id = setenv("RKVST_APPREG_CLIENT", "yyyyyyyyyyyyyyyyyyyy")
+        self.client_secret = setenv("RKVST_APPREG_SECRET", "zzzzzzzzzzzzzzzzzzzz")
 
     def tearDown(self):
-        unsetenv("TEST_ARCHIVIST", self.archivist)
-        unsetenv("TEST_AUTHTOKEN", self.authtoken)
-        unsetenv("TEST_CLIENT_ID", self.client_id)
-        unsetenv("TEST_CLIENT_SECRET", self.client_secret)
+        unsetenv("RKVST_URL", self.archivist)
+        unsetenv("RKVST_AUTHTOKEN", self.authtoken)
+        unsetenv("RKVST_APPREG_CLIENT", self.client_id)
+        unsetenv("RKVST_APPREG_SECRET", self.client_secret)
 
     def test_manage_credentials(self):
         """
@@ -50,19 +50,17 @@ class TestNotebooks(TestCase):
         ) as notebook:
             self.assertEqual(
                 notebook.ref("URL"),
-                os.getenv("TEST_ARCHIVIST"),
+                os.getenv("RKVST_URL"),
                 msg="Incorrect URL",
             )
             self.assertEqual(
                 notebook.ref("auth_token"),
-                os.getenv("TEST_AUTHTOKEN"),
+                os.getenv("RKVST_AUTHTOKEN"),
                 msg="Incorrect AUTHTOKEN",
             )
             self.assertEqual(
                 notebook.cell_output_text(5),
-                str(
-                    Archivist(os.getenv("TEST_ARCHIVIST"), os.getenv("TEST_AUTHTOKEN"))
-                ),
+                str(Archivist(os.getenv("RKVST_URL"), os.getenv("RKVST_AUTHTOKEN"))),
                 msg="Incorrect Archivist",
             )
             self.assertEqual(

--- a/unittests/testpublic.py
+++ b/unittests/testpublic.py
@@ -22,8 +22,8 @@ from .mock_response import MockResponse
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 
 class TestPublic(TestCase):

--- a/unittests/testpublicassetattachments.py
+++ b/unittests/testpublicassetattachments.py
@@ -21,8 +21,8 @@ from .mock_response import MockResponse
 
 # pylint: disable=protected-access
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testpublicassets.py
+++ b/unittests/testpublicassets.py
@@ -13,8 +13,8 @@ from archivist.logger import set_logger
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testpublicassetsread.py
+++ b/unittests/testpublicassetsread.py
@@ -26,8 +26,8 @@ from .testpublicassets import (
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testpublicevents.py
+++ b/unittests/testpublicevents.py
@@ -24,8 +24,8 @@ from .testeventsconstants import (
 from .mock_response import MockResponse
 from .testevents import IDENTITY
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunner.py
+++ b/unittests/testrunner.py
@@ -17,8 +17,8 @@ from archivist.constants import ASSET_BEHAVIOURS
 from archivist.logger import set_logger
 from archivist.runner import tree
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunneractiomap.py
+++ b/unittests/testrunneractiomap.py
@@ -15,8 +15,8 @@ from archivist.archivist import Archivist
 from archivist.runner import _ActionMap
 from archivist.logger import set_logger
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunnerassets.py
+++ b/unittests/testrunnerassets.py
@@ -18,8 +18,8 @@ from archivist.errors import ArchivistInvalidOperationError
 from archivist.events import Event
 from archivist.logger import set_logger
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunnercompliance.py
+++ b/unittests/testrunnercompliance.py
@@ -16,8 +16,8 @@ from archivist.compliance import Compliance
 from archivist.compliance_policies import CompliancePolicy
 from archivist.logger import set_logger
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunnerlocation.py
+++ b/unittests/testrunnerlocation.py
@@ -19,8 +19,8 @@ from archivist.constants import (
 
 from archivist.logger import set_logger
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunnerstep.py
+++ b/unittests/testrunnerstep.py
@@ -17,8 +17,8 @@ from archivist.logger import set_logger
 ASSET_ID = "assets/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
 LOCATION_ID = "locations/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -29,8 +29,8 @@ from .mock_response import MockResponse
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 IDENTITY = f"{SBOMS_LABEL}/c3da0d3a-32bf-4f5f-a8c6-b342a8356480"
 PROPS = {

--- a/unittests/testsubjects.py
+++ b/unittests/testsubjects.py
@@ -18,8 +18,8 @@ from archivist.logger import set_logger
 
 from .mock_response import MockResponse
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access

--- a/unittests/testtenancies.py
+++ b/unittests/testtenancies.py
@@ -29,8 +29,8 @@ RESPONSE_PUBLICINFO = {
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "TEST_DEBUG" in environ and environ["TEST_DEBUG"]:
-    set_logger(environ["TEST_DEBUG"])
+if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
+    set_logger(environ["RKVST_DEBUG"])
 
 LOGGER = getLogger(__name__)
 


### PR DESCRIPTION
Problem:
Environment variables are confusingly named differently throughout the whole repo.

Solution:
Consistent naming introduced.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>