### PR TITLE
Functional tests debug output

### DIFF
--- a/functests/__init__.py
+++ b/functests/__init__.py
@@ -1,7 +1,3 @@
 """
 functional tests
 """
-import unittest
-
-# Hides Docstring
-unittest.TestCase.shortDescription = lambda x: None

--- a/functests/constants.py
+++ b/functests/constants.py
@@ -1,0 +1,11 @@
+"""
+hide docstringss
+"""
+# pylint: disable=missing-docstring
+import unittest
+
+
+class TestCase(unittest.TestCase):
+    #  ....
+    def shortDescription(self):
+        return None

--- a/functests/execapplications.py
+++ b/functests/execapplications.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from json import dumps as json_dumps
 from os import getenv
 from time import sleep
-from unittest import TestCase, skipIf
+from unittest import skipIf
 from uuid import uuid4
 
 from archivist.archivist import Archivist
@@ -14,6 +14,8 @@ from archivist.proof_mechanism import ProofMechanism
 from archivist.utils import get_auth
 
 from archivist import logger
+
+from .constants import TestCase
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
@@ -32,10 +34,8 @@ ATTRS = {
     "some_custom_attribute": "value",
 }
 
-if getenv("RKVST_DEBUG") is not None:
-    logger.set_logger(getenv("RKVST_DEBUG"))
-else:
-    logger.set_logger("INFO")
+if getenv("RKVST_LOGLEVEL") is not None:
+    logger.set_logger(getenv("RKVST_LOGLEVEL"))
 
 LOGGER = logger.LOGGER
 
@@ -69,7 +69,7 @@ class TestApplications(TestCase):
             self.display_name,
             CUSTOM_CLAIMS,
         )
-        print("create application", json_dumps(application, indent=4))
+        LOGGER.debug("create application %s", json_dumps(application, indent=4))
         self.assertEqual(
             application["display_name"],
             self.display_name,
@@ -84,7 +84,7 @@ class TestApplications(TestCase):
             self.display_name,
             CUSTOM_CLAIMS,
         )
-        print("create application", json_dumps(application, indent=4))
+        LOGGER.debug("create application %s", json_dumps(application, indent=4))
         self.assertEqual(
             application["display_name"],
             self.display_name,
@@ -95,7 +95,7 @@ class TestApplications(TestCase):
             display_name=self.display_name,
             custom_claims=CUSTOM_CLAIMS,
         )
-        print("update application", json_dumps(application, indent=4))
+        LOGGER.debug("update application %s", json_dumps(application, indent=4))
 
     def test_applications_delete(self):
         """
@@ -105,7 +105,7 @@ class TestApplications(TestCase):
             self.display_name,
             CUSTOM_CLAIMS,
         )
-        print("create application", json_dumps(application, indent=4))
+        LOGGER.debug("create application %s", json_dumps(application, indent=4))
         self.assertEqual(
             application["display_name"],
             self.display_name,
@@ -114,7 +114,7 @@ class TestApplications(TestCase):
         application = self.arch.applications.delete(
             application["identity"],
         )
-        print("delete application", json_dumps(application, indent=4))
+        LOGGER.debug("delete application %s", json_dumps(application, indent=4))
         self.assertEqual(
             application,
             {},
@@ -129,7 +129,7 @@ class TestApplications(TestCase):
             self.display_name,
             CUSTOM_CLAIMS,
         )
-        print("create application", json_dumps(application, indent=4))
+        LOGGER.debug("create application %s", json_dumps(application, indent=4))
         self.assertEqual(
             application["display_name"],
             self.display_name,
@@ -138,7 +138,7 @@ class TestApplications(TestCase):
         application = self.arch.applications.regenerate(
             application["identity"],
         )
-        print("regenerate application", json_dumps(application, indent=4))
+        LOGGER.debug("regenerate application %s", json_dumps(application, indent=4))
 
     def test_applications_list(self):
         """
@@ -155,7 +155,7 @@ class TestApplications(TestCase):
             msg="Incorrect display name",
         )
         for application in applications:
-            print("application", json_dumps(application, indent=4))
+            LOGGER.debug("application %s", json_dumps(application, indent=4))
 
         for application in applications:
             self.assertGreater(
@@ -177,7 +177,7 @@ class TestApplications(TestCase):
             self.display_name,
             CUSTOM_CLAIMS,
         )
-        print("create application", json_dumps(application, indent=4))
+        LOGGER.debug("create application %s", json_dumps(application, indent=4))
         self.assertEqual(
             application["display_name"],
             self.display_name,
@@ -187,7 +187,7 @@ class TestApplications(TestCase):
             application["client_id"],
             application["credentials"][0]["secret"],
         )
-        print("appidp", json_dumps(appidp, indent=4))
+        LOGGER.debug("appidp %s", json_dumps(appidp, indent=4))
 
     def test_appidp_token_404(self):
         """
@@ -214,12 +214,12 @@ class TestApplications(TestCase):
         Test archivist with client id/secret
         WARN: this test takes over 10 minutes
         """
-        print("This test takes over 10 minutes...")
+        LOGGER.debug("This test takes over 10 minutes...")
         application = self.arch.applications.create(
             self.display_name,
             CUSTOM_CLAIMS,
         )
-        print("create application", json_dumps(application, indent=4))
+        LOGGER.debug("create application %s", json_dumps(application, indent=4))
         self.assertEqual(
             application["display_name"],
             self.display_name,
@@ -227,7 +227,7 @@ class TestApplications(TestCase):
         )
 
         # archivist using app registration
-        print("New Arch")
+        LOGGER.debug("New Arch")
         with Archivist(
             getenv("RKVST_URL"),
             (application["client_id"], application["credentials"][0]["secret"]),
@@ -245,7 +245,7 @@ class TestApplications(TestCase):
                 attrs=traffic_light,
                 confirm=True,
             )
-            print("create asset", json_dumps(asset, indent=4))
+            LOGGER.debug("create asset %s", json_dumps(asset, indent=4))
             self.assertEqual(
                 asset["proof_mechanism"],
                 ProofMechanism.SIMPLE_HASH.name,
@@ -268,4 +268,4 @@ class TestApplications(TestCase):
                     },
                     confirm=True,
                 )
-                print(i, "create event", json_dumps(event, indent=4))
+                LOGGER.debug("%d: create event %s", i, json_dumps(event, indent=4))

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -5,7 +5,6 @@ Test assets creation
 from copy import copy, deepcopy
 from json import dumps as json_dumps
 from os import getenv
-from unittest import TestCase
 from uuid import uuid4
 
 from archivist.archivist import Archivist
@@ -15,15 +14,15 @@ from archivist.utils import get_auth
 
 from archivist import logger
 
+from .constants import TestCase
+
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
 
 
-if getenv("RKVST_DEBUG") is not None:
-    logger.set_logger(getenv("RKVST_DEBUG"))
-else:
-    logger.set_logger("INFO")
+if getenv("RKVST_LOGLEVEL") is not None:
+    logger.set_logger(getenv("RKVST_LOGLEVEL"))
 
 LOGGER = logger.LOGGER
 
@@ -103,14 +102,14 @@ class TestAssetCreate(TestCase):
             attrs=self.traffic_light,
             confirm=True,
         )
-        print("asset", json_dumps(asset, sort_keys=True, indent=4))
+        LOGGER.debug("asset %s", json_dumps(asset, sort_keys=True, indent=4))
         self.assertEqual(
             asset["proof_mechanism"],
             ProofMechanism.SIMPLE_HASH.name,
             msg="Incorrect asset proof mechanism",
         )
         tenancy = self.arch.tenancies.publicinfo(asset["tenant_identity"])
-        print("tenancy", json_dumps(tenancy, sort_keys=True, indent=4))
+        LOGGER.debug("tenancy %s", json_dumps(tenancy, sort_keys=True, indent=4))
 
     def test_asset_create_khipu(self):
         """
@@ -122,21 +121,21 @@ class TestAssetCreate(TestCase):
             },
             attrs=self.traffic_light,
         )
-        print("asset", json_dumps(asset, sort_keys=True, indent=4))
+        LOGGER.debug("asset %s", json_dumps(asset, sort_keys=True, indent=4))
         self.assertEqual(
             asset["proof_mechanism"],
             ProofMechanism.KHIPU.name,
             msg="Incorrect asset proof mechanism",
         )
         tenancy = self.arch.tenancies.publicinfo(asset["tenant_identity"])
-        print("tenancy", json_dumps(tenancy, sort_keys=True, indent=4))
+        LOGGER.debug("tenancy %s", json_dumps(tenancy, sort_keys=True, indent=4))
 
         events = self.arch.events.list(asset_id=asset["identity"])
-        print("events", json_dumps(list(events), sort_keys=True, indent=4))
+        LOGGER.debug("events %s", json_dumps(list(events), sort_keys=True, indent=4))
         asset = self.arch.events.wait_for_confirmation(asset["identity"])
-        print("asset", json_dumps(asset, sort_keys=True, indent=4))
+        LOGGER.debug("asset %s", json_dumps(asset, sort_keys=True, indent=4))
         events = self.arch.events.list(asset_id=asset["identity"])
-        print("events", json_dumps(list(events), sort_keys=True, indent=4))
+        LOGGER.debug("events %s", json_dumps(list(events), sort_keys=True, indent=4))
 
     def test_asset_create_with_fixtures(self):
         """
@@ -226,10 +225,10 @@ class TestAssetCreate(TestCase):
         event = self.arch.events.create(
             identity, props=props, attrs=attrs, confirm=True
         )
-        print("event", json_dumps(event, sort_keys=True, indent=4))
+        LOGGER.debug("event %s", json_dumps(event, sort_keys=True, indent=4))
 
         tenancy = self.arch.tenancies.publicinfo(event["tenant_identity"])
-        print("tenancy", json_dumps(tenancy, sort_keys=True, indent=4))
+        LOGGER.debug("tenancy %s", json_dumps(tenancy, sort_keys=True, indent=4))
 
 
 class TestAssetCreateIfNotExists(TestCase):
@@ -268,8 +267,8 @@ class TestAssetCreateIfNotExists(TestCase):
             REQUEST_EXISTS_ATTACHMENTS,
             confirm=True,
         )
-        print("asset", json_dumps(asset, indent=4))
-        print("existed", existed)
+        LOGGER.debug("asset %s", json_dumps(asset, indent=4))
+        LOGGER.debug("existed %s", existed)
 
         # first attachment is ok....
         attachment_id = asset["attributes"]["arc_attachments"][0][
@@ -278,12 +277,12 @@ class TestAssetCreateIfNotExists(TestCase):
         info = self.arch.attachments.info(
             attachment_id,
         )
-        print("info attachment1", json_dumps(info, indent=4))
+        LOGGER.debug("info attachment1 %s", json_dumps(info, indent=4))
         timestamp = info["scanned_timestamp"]
         if timestamp:
-            print(attachment_id, "scanned last at", timestamp)
-            print(attachment_id, "scanned status", info["scanned_status"])
-            print(attachment_id, "scanned reason", info["scanned_reason"])
+            LOGGER.debug("%d: scanned last at %s", attachment_id, timestamp)
+            LOGGER.debug("%d: scanned status %s", attachment_id, info["scanned_status"])
+            LOGGER.debug("%d: scanned reason %s", attachment_id, info["scanned_reason"])
             self.assertEqual(
                 info["scanned_status"],
                 "SCANNED_OK",
@@ -297,12 +296,12 @@ class TestAssetCreateIfNotExists(TestCase):
         info = self.arch.attachments.info(
             attachment_id,
         )
-        print("info attachment1", json_dumps(info, indent=4))
+        LOGGER.debug("info attachment1 %s", json_dumps(info, indent=4))
         timestamp = info["scanned_timestamp"]
         if timestamp:
-            print(attachment_id, "scanned last at", timestamp)
-            print(attachment_id, "scanned status", info["scanned_status"])
-            print(attachment_id, "scanned reason", info["scanned_reason"])
+            LOGGER.debug("%d: scanned last at %s", attachment_id, timestamp)
+            LOGGER.debug("%d: scanned status %s", attachment_id, info["scanned_status"])
+            LOGGER.debug("%d: scanned reason %s", attachment_id, info["scanned_reason"])
             self.assertEqual(
                 info["scanned_status"],
                 "SCANNED_BAD",
@@ -324,8 +323,8 @@ class TestAssetCreateIfNotExists(TestCase):
             REQUEST_EXISTS_ATTACHMENTS,
             confirm=True,
         )
-        print("asset", json_dumps(asset, indent=4))
-        print("existed", existed)
+        LOGGER.debug("asset %s", json_dumps(asset, indent=4))
+        LOGGER.debug("existed %s", existed)
 
         # first attachment is ok....
         attachment_id = asset["attributes"]["arc_attachments"][0][
@@ -335,12 +334,12 @@ class TestAssetCreateIfNotExists(TestCase):
             asset["identity"],
             attachment_id,
         )
-        print("info attachment1", json_dumps(info, indent=4))
+        LOGGER.debug("info attachment1 %s", json_dumps(info, indent=4))
         timestamp = info["scanned_timestamp"]
         if timestamp:
-            print(attachment_id, "scanned last at", timestamp)
-            print(attachment_id, "scanned status", info["scanned_status"])
-            print(attachment_id, "scanned reason", info["scanned_reason"])
+            LOGGER.debug("%d: scanned last at %s", attachment_id, timestamp)
+            LOGGER.debug("%d: scanned status %s", attachment_id, info["scanned_status"])
+            LOGGER.debug("%d: scanned reason %s", attachment_id, info["scanned_reason"])
             self.assertEqual(
                 info["scanned_status"],
                 "SCANNED_OK",
@@ -355,12 +354,12 @@ class TestAssetCreateIfNotExists(TestCase):
             asset["identity"],
             attachment_id,
         )
-        print("info attachment1", json_dumps(info, indent=4))
+        LOGGER.debug("info attachment1 %s", json_dumps(info, indent=4))
         timestamp = info["scanned_timestamp"]
         if timestamp:
-            print(attachment_id, "scanned last at", timestamp)
-            print(attachment_id, "scanned status", info["scanned_status"])
-            print(attachment_id, "scanned reason", info["scanned_reason"])
+            LOGGER.debug("%d: scanned last at %s", attachment_id, timestamp)
+            LOGGER.debug("%d: scanned status %s", attachment_id, info["scanned_status"])
+            LOGGER.debug("%d: scanned reason %s", attachment_id, info["scanned_reason"])
             self.assertEqual(
                 info["scanned_status"],
                 "SCANNED_BAD",

--- a/functests/execattachments.py
+++ b/functests/execattachments.py
@@ -6,7 +6,7 @@ from filecmp import clear_cache, cmp
 from json import dumps as json_dumps
 from io import BytesIO
 from os import getenv, remove
-from unittest import TestCase, skipIf
+from unittest import skipIf
 
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistBadRequestError
@@ -14,10 +14,10 @@ from archivist.utils import get_auth, get_url
 
 from archivist import logger
 
-if getenv("RKVST_DEBUG") is not None:
-    logger.set_logger(getenv("RKVST_DEBUG"))
-else:
-    logger.set_logger("INFO")
+from .constants import TestCase
+
+if getenv("RKVST_LOGLEVEL") is not None:
+    logger.set_logger(getenv("RKVST_LOGLEVEL"))
 
 LOGGER = logger.LOGGER
 
@@ -89,7 +89,7 @@ class TestAttachmentsCreate(TestCase):
             attachment = self.arch.attachments.upload(fd)
             file_uuid = attachment["identity"]
 
-        print("attachment", json_dumps(attachment, indent=4))
+        LOGGER.debug("attachment %s", json_dumps(attachment, indent=4))
 
         self.assertEqual(
             attachment["mime_type"],
@@ -100,7 +100,7 @@ class TestAttachmentsCreate(TestCase):
         with open(self.RKVST_DOCX_DOWNLOAD_PATH, "wb") as fd:
             attachment = self.arch.attachments.download(file_uuid, fd)
 
-        print("attachment", attachment.headers)
+        LOGGER.debug("attachment %s", attachment.headers)
         self.assertEqual(
             attachment.headers["content-type"],
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -125,7 +125,7 @@ class TestAttachmentsCreate(TestCase):
         """
         file_uuid = getenv("RKVST_BLOB_IDENTITY")
         info = self.arch.attachments.info(file_uuid)
-        print("attachment info", json_dumps(info, indent=4))
+        LOGGER.debug("attachment info %s", json_dumps(info, indent=4))
 
     def test_attachment_upload_and_download_allow_insecure(self):
         """
@@ -205,33 +205,33 @@ class TestAttachmentstMalware(TestCase):
         Test file upload through the SDK
         """
         attachment = self.arch.attachments.upload(self.malware1)
-        print("attachment", json_dumps(attachment, indent=4))
+        LOGGER.debug("attachment %s", json_dumps(attachment, indent=4))
         response = self.arch.attachments.info(attachment["identity"])
-        print("response", json_dumps(response, indent=4))
+        LOGGER.debug("response %s", json_dumps(response, indent=4))
 
     def test_attachment_malware_scan2(self):
         """
         Test file upload through the SDK
         """
         attachment = self.arch.attachments.upload(self.malware2)
-        print("attachment", json_dumps(attachment, indent=4))
+        LOGGER.debug("attachment %s", json_dumps(attachment, indent=4))
         response = self.arch.attachments.info(attachment["identity"])
-        print("response", json_dumps(response, indent=4))
+        LOGGER.debug("response %s", json_dumps(response, indent=4))
 
     def test_attachment_malware_scan3(self):
         """
         Test file upload through the SDK
         """
         attachment = self.arch.attachments.upload(self.malware3)
-        print("attachment", json_dumps(attachment, indent=4))
+        LOGGER.debug("attachment %s", json_dumps(attachment, indent=4))
         response = self.arch.attachments.info(attachment["identity"])
-        print("response", json_dumps(response, indent=4))
+        LOGGER.debug("response %s", json_dumps(response, indent=4))
 
     def test_attachment_malware_scan4(self):
         """
         Test file upload through the SDK
         """
         attachment = self.arch.attachments.upload(self.malware4)
-        print("attachment", json_dumps(attachment, indent=4))
+        LOGGER.debug("attachment %s", json_dumps(attachment, indent=4))
         response = self.arch.attachments.info(attachment["identity"])
-        print("response", json_dumps(response, indent=4))
+        LOGGER.debug("response %s", json_dumps(response, indent=4))

--- a/functests/execcompliance_policies.py
+++ b/functests/execcompliance_policies.py
@@ -4,7 +4,6 @@ Test compliance policies
 from json import dumps as json_dumps
 from os import getenv
 from time import sleep
-from unittest import TestCase
 from uuid import uuid4
 
 from archivist.archivist import Archivist
@@ -20,14 +19,14 @@ from archivist.utils import get_auth
 
 from archivist import logger
 
+from .constants import TestCase
+
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
 
-if getenv("RKVST_DEBUG") is not None:
-    logger.set_logger(getenv("RKVST_DEBUG"))
-else:
-    logger.set_logger("INFO")
+if getenv("RKVST_LOGLEVEL") is not None:
+    logger.set_logger(getenv("RKVST_LOGLEVEL"))
 
 LOGGER = logger.LOGGER
 
@@ -100,7 +99,6 @@ class TestCompliancePoliciesBase(TestCase):
             client_secret_filename=getenv("RKVST_APPREG_SECRET_FILENAME"),
         )
         self.arch = Archivist(getenv("RKVST_URL"), auth, verify=False)
-        print()
 
     def tearDown(self):
         self.arch.close()
@@ -119,7 +117,7 @@ class TestCompliancePolicies(TestCompliancePoliciesBase):
             SINCE_POLICY.display_name,
             msg="Incorrect display name",
         )
-        print("SINCE_POLICY:", json_dumps(compliance_policy, indent=4))
+        LOGGER.debug("SINCE_POLICY: %s", json_dumps(compliance_policy, indent=4))
         self.arch.compliance_policies.delete(
             compliance_policy["identity"],
         )
@@ -136,7 +134,7 @@ class TestCompliancePolicies(TestCompliancePoliciesBase):
             RICHNESS_POLICY.display_name,
             msg="Incorrect display name",
         )
-        print("RICHNESS_POLICY:", json_dumps(compliance_policy, indent=4))
+        LOGGER.debug("RICHNESS_POLICY: %s", json_dumps(compliance_policy, indent=4))
         self.arch.compliance_policies.delete(
             compliance_policy["identity"],
         )
@@ -153,7 +151,9 @@ class TestCompliancePolicies(TestCompliancePoliciesBase):
             DYNAMIC_TOLERANCE_POLICY.display_name,
             msg="Incorrect display name",
         )
-        print("DYNAMIC_TOLERANCE_POLICY:", json_dumps(compliance_policy, indent=4))
+        LOGGER.debug(
+            "DYNAMIC_TOLERANCE_POLICY: %s", json_dumps(compliance_policy, indent=4)
+        )
         self.arch.compliance_policies.delete(
             compliance_policy["identity"],
         )
@@ -170,7 +170,9 @@ class TestCompliancePolicies(TestCompliancePoliciesBase):
             CURRENT_OUTSTANDING_POLICY.display_name,
             msg="Incorrect display name",
         )
-        print("CURRENT_OUTSTANDING_POLICY:", json_dumps(compliance_policy, indent=4))
+        LOGGER.debug(
+            "CURRENT_OUTSTANDING_POLICY: %s", json_dumps(compliance_policy, indent=4)
+        )
         self.arch.compliance_policies.delete(
             compliance_policy["identity"],
         )
@@ -187,7 +189,9 @@ class TestCompliancePolicies(TestCompliancePoliciesBase):
             PERIOD_OUTSTANDING_POLICY.display_name,
             msg="Incorrect display name",
         )
-        print("PERIOD_OUTSTANDING_POLICY:", json_dumps(compliance_policy, indent=4))
+        LOGGER.debug(
+            "PERIOD_OUTSTANDING_POLICY: %s", json_dumps(compliance_policy, indent=4)
+        )
         self.arch.compliance_policies.delete(
             compliance_policy["identity"],
         )
@@ -198,7 +202,7 @@ class TestCompliancePolicies(TestCompliancePoliciesBase):
         """
         compliance_policies = list(self.arch.compliance_policies.list())
         for i, compliance_policy in enumerate(compliance_policies):
-            print(i, ":", json_dumps(compliance_policy, indent=4))
+            LOGGER.debug("%d: %s", i, json_dumps(compliance_policy, indent=4))
             self.assertGreater(
                 len(compliance_policy["display_name"]),
                 0,
@@ -215,29 +219,29 @@ class TestCompliancePolicies(TestCompliancePoliciesBase):
         count = self.arch.compliance_policies.count(
             props={"compliance_type": CompliancePolicyType.COMPLIANCE_SINCE.name}
         )
-        print("No. of 'SINCE' compliance policies:", count)
+        LOGGER.debug("No. of 'SINCE' compliance policies: %d", count)
         count = self.arch.compliance_policies.count(
             props={"compliance_type": CompliancePolicyType.COMPLIANCE_RICHNESS.name}
         )
-        print("No. of 'RICHNESS' compliance policies:", count)
+        LOGGER.debug("No. of 'RICHNESS' compliance policies: %d", count)
         count = self.arch.compliance_policies.count(
             props={
                 "compliance_type": CompliancePolicyType.COMPLIANCE_DYNAMIC_TOLERANCE.name
             }
         )
-        print("No. of 'DYNAMIC_TOLERANCE' compliance policies:", count)
+        LOGGER.debug("No. of 'DYNAMIC_TOLERANCE' compliance policies: %d", count)
         count = self.arch.compliance_policies.count(
             props={
                 "compliance_type": CompliancePolicyType.COMPLIANCE_CURRENT_OUTSTANDING.name
             }
         )
-        print("No. of 'CURRENT_OUTSTANDING' compliance policies:", count)
+        LOGGER.debug("No. of 'CURRENT_OUTSTANDING' compliance policies: %d", count)
         count = self.arch.compliance_policies.count(
             props={
                 "compliance_type": CompliancePolicyType.COMPLIANCE_PERIOD_OUTSTANDING.name
             }
         )
-        print("No. of 'PERIOD_OUTSTANDING' compliance policies:", count)
+        LOGGER.debug("No. of 'PERIOD_OUTSTANDING' compliance policies: %d", count)
 
 
 TRAFFIC_LIGHT = {
@@ -269,13 +273,13 @@ class TestCompliancePoliciesCompliantAt(TestCompliancePoliciesBase):
                 time_period_seconds=10,  # very short so we can test
             )
         )
-        print("SINCE_POLICY:", json_dumps(compliance_policy, indent=4))
+        LOGGER.debug("SINCE_POLICY: %s", json_dumps(compliance_policy, indent=4))
 
         traffic_light = self.arch.assets.create(
             attrs=TRAFFIC_LIGHT,
             confirm=True,
         )
-        print("TRAFFIC_LIGHT:", json_dumps(traffic_light, indent=4))
+        LOGGER.debug("TRAFFIC_LIGHT: %s", json_dumps(traffic_light, indent=4))
 
         maintenance_performed = self.arch.events.create(
             traffic_light["identity"],
@@ -286,25 +290,27 @@ class TestCompliancePoliciesCompliantAt(TestCompliancePoliciesBase):
             },
             confirm=True,
         )
-        print("MAINTENANCE_PERFORMED:", json_dumps(maintenance_performed, indent=4))
+        LOGGER.debug(
+            "MAINTENANCE_PERFORMED: %s", json_dumps(maintenance_performed, indent=4)
+        )
 
-        print("Sleep 1 second...")
+        LOGGER.debug("Sleep 1 second...")
         sleep(1)
         compliance = self.arch.compliance.compliant_at(
             traffic_light["identity"],
         )
-        print("COMPLIANCE (true):", json_dumps(compliance, indent=4))
+        LOGGER.debug("COMPLIANCE (true): %s", json_dumps(compliance, indent=4))
         self.assertTrue(
             compliance["compliant"],
             msg="Assets should be compliant",
         )
 
-        print("Sleep 15 seconds...")
+        LOGGER.debug("Sleep 15 seconds...")
         sleep(15)
         compliance = self.arch.compliance.compliant_at(
             traffic_light["identity"],
         )
-        print("COMPLIANCE (false):", json_dumps(compliance, indent=4))
+        LOGGER.debug("COMPLIANCE (false): %s", json_dumps(compliance, indent=4))
         self.assertFalse(
             compliance["compliant"],
             msg="Assets should not be compliant",
@@ -330,13 +336,15 @@ class TestCompliancePoliciesCompliantAt(TestCompliancePoliciesBase):
                 closing_event_display_type=f"Maintenance Performed {tag}",
             ),
         )
-        print("CURRENT_OUTSTANDING_POLICY:", json_dumps(compliance_policy, indent=4))
+        LOGGER.debug(
+            "CURRENT_OUTSTANDING_POLICY: %s", json_dumps(compliance_policy, indent=4)
+        )
 
         traffic_light = self.arch.assets.create(
             attrs=TRAFFIC_LIGHT,
             confirm=True,
         )
-        print("TRAFFIC_LIGHT:", json_dumps(traffic_light, indent=4))
+        LOGGER.debug("TRAFFIC_LIGHT: %s", json_dumps(traffic_light, indent=4))
 
         maintenance_request = self.arch.events.create(
             traffic_light["identity"],
@@ -348,15 +356,17 @@ class TestCompliancePoliciesCompliantAt(TestCompliancePoliciesBase):
             },
             confirm=True,
         )
-        print("MAINTENANCE_REQUIRED:", json_dumps(maintenance_request, indent=4))
+        LOGGER.debug(
+            "MAINTENANCE_REQUIRED: %s", json_dumps(maintenance_request, indent=4)
+        )
 
-        print("Sleep 1 second...")
+        LOGGER.debug("Sleep 1 second...")
         sleep(1)
 
         compliance = self.arch.compliance.compliant_at(
             traffic_light["identity"],
         )
-        print("COMPLIANCE (false):", json_dumps(compliance, indent=4))
+        LOGGER.debug("COMPLIANCE (false): %s", json_dumps(compliance, indent=4))
         self.assertFalse(
             compliance["compliant"],
             msg="Assets should not be compliant",
@@ -372,15 +382,17 @@ class TestCompliancePoliciesCompliantAt(TestCompliancePoliciesBase):
             },
             confirm=True,
         )
-        print("MAINTENANCE_PERFORMED:", json_dumps(maintenance_performed, indent=4))
+        LOGGER.debug(
+            "MAINTENANCE_PERFORMED: %s", json_dumps(maintenance_performed, indent=4)
+        )
 
-        print("Sleep 1 second...")
+        LOGGER.debug("Sleep 1 second...")
         sleep(1)
 
         compliance = self.arch.compliance.compliant_at(
             traffic_light["identity"],
         )
-        print("COMPLIANCE (true):", json_dumps(compliance, indent=4))
+        LOGGER.debug("COMPLIANCE (true): %s", json_dumps(compliance, indent=4))
         self.assertTrue(
             compliance["compliant"],
             msg="Assets should be compliant",

--- a/functests/execnotebooks.py
+++ b/functests/execnotebooks.py
@@ -2,7 +2,6 @@
 Test subjects
 """
 from os import getenv
-from unittest import TestCase
 
 from testbook import testbook
 
@@ -14,10 +13,10 @@ from archivist.archivist import Archivist
 
 from archivist import logger
 
-if getenv("RKVST_DEBUG") is not None:
-    logger.set_logger(getenv("RKVST_DEBUG"))
-else:
-    logger.set_logger("INFO")
+from .constants import TestCase
+
+if getenv("RKVST_LOGLEVEL") is not None:
+    logger.set_logger(getenv("RKVST_LOGLEVEL"))
 
 LOGGER = logger.LOGGER
 

--- a/functests/execpublicassets.py
+++ b/functests/execpublicassets.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from json import dumps as json_dumps
 from os import getenv
 from time import sleep
-from unittest import TestCase
 
 from archivist.archivist import Archivist
 from archivist.constants import ASSET_BEHAVIOURS
@@ -16,15 +15,15 @@ from archivist.utils import get_auth
 
 from archivist import logger
 
+from .constants import TestCase
+
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
 
 
-if getenv("RKVST_DEBUG") is not None:
-    logger.set_logger(getenv("RKVST_DEBUG"))
-else:
-    logger.set_logger("INFO")
+if getenv("RKVST_LOGLEVEL") is not None:
+    logger.set_logger(getenv("RKVST_LOGLEVEL"))
 
 LOGGER = logger.LOGGER
 
@@ -107,7 +106,7 @@ class TestPublicAssetCreate(TestCase):
             },
             confirm=True,
         )
-        print("asset", json_dumps(asset, sort_keys=True, indent=4))
+        LOGGER.debug("asset %s", json_dumps(asset, sort_keys=True, indent=4))
         self.assertEqual(
             asset["proof_mechanism"],
             ProofMechanism.SIMPLE_HASH.name,
@@ -119,12 +118,12 @@ class TestPublicAssetCreate(TestCase):
             msg="Asset is not public",
         )
         asset_publicurl = self.arch.assets.publicurl(asset["identity"])
-        print("asset_publicurl", asset_publicurl)
+        LOGGER.debug("asset_publicurl %s", asset_publicurl)
         public = self.arch.Public
         count = public.events.count(asset_id=asset_publicurl)
-        print("count", count)
+        LOGGER.debug("count %s", count)
         events = public.events.list(asset_id=asset_publicurl)
-        print("events", json_dumps(list(events), sort_keys=True, indent=4))
+        LOGGER.debug("events %s", json_dumps(list(events), sort_keys=True, indent=4))
 
     def test_public_asset_create_khipu(self):
         """
@@ -138,7 +137,7 @@ class TestPublicAssetCreate(TestCase):
             },
             confirm=True,
         )
-        print("asset", json_dumps(asset, sort_keys=True, indent=4))
+        LOGGER.debug("asset %s", json_dumps(asset, sort_keys=True, indent=4))
         self.assertEqual(
             asset["proof_mechanism"],
             ProofMechanism.KHIPU.name,
@@ -150,12 +149,12 @@ class TestPublicAssetCreate(TestCase):
             msg="Asset is not public",
         )
         asset_publicurl = self.arch.assets.publicurl(asset["identity"])
-        print("publicurl", asset_publicurl)
+        LOGGER.debug("publicurl %s", asset_publicurl)
         public = self.arch.Public
         count = public.events.count(asset_id=asset_publicurl)
-        print("count", count)
+        LOGGER.debug("count %s", count)
         events = public.events.list(asset_id=asset_publicurl)
-        print("events", json_dumps(list(events), sort_keys=True, indent=4))
+        LOGGER.debug("events %s", json_dumps(list(events), sort_keys=True, indent=4))
 
     def test_public_asset_create_event(self):
         """
@@ -168,7 +167,7 @@ class TestPublicAssetCreate(TestCase):
             },
             confirm=True,
         )
-        print("asset", json_dumps(asset, sort_keys=True, indent=4))
+        LOGGER.debug("asset %s", json_dumps(asset, sort_keys=True, indent=4))
         identity = asset["identity"]
         self.assertIsNotNone(
             identity,
@@ -202,12 +201,12 @@ class TestPublicAssetCreate(TestCase):
         event = self.arch.events.create(
             identity, props=props, attrs=attrs, confirm=True
         )
-        print("event", json_dumps(event, sort_keys=True, indent=4))
+        LOGGER.debug("event %s", json_dumps(event, sort_keys=True, indent=4))
         event_publicurl = self.arch.events.publicurl(event["identity"])
 
         public = self.arch.Public
         event = public.events.read(event_publicurl)
-        print("event", json_dumps(event, sort_keys=True, indent=4))
+        LOGGER.debug("event %s", json_dumps(event, sort_keys=True, indent=4))
 
     def test_asset_create_if_not_exists_with_bad_attachment_assetattachment(self):
         """
@@ -222,13 +221,13 @@ class TestPublicAssetCreate(TestCase):
         """
         request_data = deepcopy(REQUEST_EXISTS_ATTACHMENTS)
         request_data["attributes"]["arc_namespace"] = now_timestamp()
-        print("request_data", json_dumps(request_data, indent=4))
+        LOGGER.debug("request_data %s", json_dumps(request_data, indent=4))
         asset, existed = self.arch.assets.create_if_not_exists(
             request_data,
             confirm=True,
         )
-        print("asset", json_dumps(asset, indent=4))
-        print("existed", existed)
+        LOGGER.debug("asset %s", json_dumps(asset, indent=4))
+        LOGGER.debug("existed %s", existed)
 
         asset_id = asset["identity"]
         # first attachment is ok....
@@ -236,16 +235,16 @@ class TestPublicAssetCreate(TestCase):
             "arc_attachment_identity"
         ]
         public_asset_id = self.arch.assets.publicurl(asset_id)
-        print("public asset id", public_asset_id)
+        LOGGER.debug("public asset id %s", public_asset_id)
         public = self.arch.Public
         sleep(30)  # until we implement confirmed logic
         info = public.assetattachments.info(public_asset_id, attachment_id)
-        print("info attachment1", json_dumps(info, indent=4))
+        LOGGER.debug("info attachment1 %s", json_dumps(info, indent=4))
         timestamp = info["scanned_timestamp"]
         if timestamp:
-            print(attachment_id, "scanned last at", timestamp)
-            print(attachment_id, "scanned status", info["scanned_status"])
-            print(attachment_id, "scanned reason", info["scanned_reason"])
+            LOGGER.debug("%d: scanned last at %s", attachment_id, timestamp)
+            LOGGER.debug("%d: scanned status %s", attachment_id, info["scanned_status"])
+            LOGGER.debug("%d: scanned reason %s", attachment_id, info["scanned_reason"])
             self.assertEqual(
                 info["scanned_status"],
                 "SCANNED_OK",
@@ -257,12 +256,12 @@ class TestPublicAssetCreate(TestCase):
             "arc_attachment_identity"
         ]
         info = public.assetattachments.info(public_asset_id, attachment_id)
-        print("info attachment1", json_dumps(info, indent=4))
+        LOGGER.debug("info attachment1 %s", json_dumps(info, indent=4))
         timestamp = info["scanned_timestamp"]
         if timestamp:
-            print(attachment_id, "scanned last at", timestamp)
-            print(attachment_id, "scanned status", info["scanned_status"])
-            print(attachment_id, "scanned reason", info["scanned_reason"])
+            LOGGER.debug("%d: scanned last at %s", attachment_id, timestamp)
+            LOGGER.debug("%d: scanned status %s", attachment_id, info["scanned_status"])
+            LOGGER.debug("%d: scanned reason %s", attachment_id, info["scanned_reason"])
             self.assertEqual(
                 info["scanned_status"],
                 "SCANNED_BAD",

--- a/functests/execrunner.py
+++ b/functests/execrunner.py
@@ -3,7 +3,6 @@ Test runner
 """
 
 from os import getenv, environ
-from unittest import TestCase
 
 from jinja2 import Environment, FileSystemLoader
 from pyaml_env import parse_config
@@ -14,15 +13,15 @@ from archivist.utils import get_auth
 
 from archivist import logger
 
+from .constants import TestCase
+
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
 
 
-if getenv("RKVST_DEBUG") is not None:
-    logger.set_logger(getenv("RKVST_DEBUG"))
-else:
-    logger.set_logger("INFO")
+if getenv("RKVST_LOGLEVEL") is not None:
+    logger.set_logger(getenv("RKVST_LOGLEVEL"))
 
 LOGGER = logger.LOGGER
 
@@ -54,7 +53,7 @@ class TestRunner(TestCase):
 
         run_steps is used so that exceptions are shown
         """
-        LOGGER.info("...")
+        LOGGER.debug("...")
         with open(
             "functests/test_resources/dynamic_tolerance_story.yaml",
             "r",
@@ -76,7 +75,7 @@ class TestRunner(TestCase):
         run_steps is used so that exceptions are shown
         """
 
-        LOGGER.info("...")
+        LOGGER.debug("...")
         jinja = Environment(
             loader=FileSystemLoader("functests/test_resources"),
             trim_blocks=True,
@@ -117,7 +116,7 @@ class TestRunner(TestCase):
         run_steps is used so that exceptions are shown
         """
 
-        LOGGER.info("...")
+        LOGGER.debug("...")
         with open(
             "functests/test_resources/richness_story.yaml",
             "r",
@@ -139,7 +138,7 @@ class TestRunner(TestCase):
         run_steps is used so that exceptions are shown
         """
 
-        LOGGER.info("...")
+        LOGGER.debug("...")
         with open(
             "functests/test_resources/door_entry_story.yaml",
             "r",
@@ -158,7 +157,7 @@ class TestRunner(TestCase):
         run_steps is used so that exceptions are shown
         """
 
-        LOGGER.info("...")
+        LOGGER.debug("...")
         with open(
             "functests/test_resources/estate_info_story.yaml",
             "r",
@@ -175,7 +174,7 @@ class TestRunner(TestCase):
         run_steps is used so that exceptions are shown
         """
 
-        LOGGER.info("...")
+        LOGGER.debug("...")
         with open(
             "functests/test_resources/wipp_story.yaml",
             "r",
@@ -195,7 +194,7 @@ class TestRunner(TestCase):
         run_steps is used so that exceptions are shown
         """
 
-        LOGGER.info("...")
+        LOGGER.debug("...")
         with open(
             "functests/test_resources/sbom_story.yaml",
             "r",
@@ -215,7 +214,7 @@ class TestRunner(TestCase):
         run_steps is used so that exceptions are shown
         """
 
-        LOGGER.info("...")
+        LOGGER.debug("...")
         with open(
             "functests/test_resources/subjects_story.yaml",
             "r",

--- a/functests/execsboms.py
+++ b/functests/execsboms.py
@@ -6,7 +6,6 @@ from filecmp import clear_cache, cmp
 from json import dumps as json_dumps
 from os import getenv, remove
 from time import sleep
-from unittest import TestCase
 
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistBadRequestError
@@ -14,6 +13,8 @@ from archivist.timestamp import now_timestamp
 from archivist.utils import get_auth
 
 from archivist import logger
+
+from .constants import TestCase
 
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
@@ -30,10 +31,8 @@ RKVST_SBOM_PATH = "functests/test_resources/bom.xml"
 RKVST_SBOM_SPDX_PATH = "functests/test_resources/bom.spdx"
 RKVST_SBOM_DOWNLOAD_PATH = "functests/test_resources/downloaded_bom.xml"
 
-if getenv("RKVST_DEBUG") is not None:
-    logger.set_logger(getenv("RKVST_DEBUG"))
-else:
-    logger.set_logger("INFO")
+if getenv("RKVST_LOGLEVEL") is not None:
+    logger.set_logger(getenv("RKVST_LOGLEVEL"))
 
 LOGGER = logger.LOGGER
 
@@ -71,16 +70,16 @@ class TestSBOM(TestCase):
         Test sbom upload with privacy
         """
         now = now_timestamp()
-        print("Public Upload Title:", self.title, now)
+        LOGGER.debug("Public Upload Title: %s %s", self.title, now)
         with open(RKVST_SBOM_PATH, "rb") as fd:
             metadata = self.arch.sboms.upload(
                 fd, confirm=True, params={"privacy": "PRIVATE"}
             )
-        print("first upload", json_dumps(metadata.dict(), indent=4))
+        LOGGER.debug("first upload %s", json_dumps(metadata.dict(), indent=4))
         identity = metadata.identity
 
         metadata1 = self.arch.sboms.read(identity)
-        print("read", json_dumps(metadata1.dict(), indent=4))
+        LOGGER.debug("read %s", json_dumps(metadata1.dict(), indent=4))
         self.assertEqual(
             metadata,
             metadata1,
@@ -92,7 +91,7 @@ class TestSBOM(TestCase):
         Test sbom upload with privacy
         """
         now = now_timestamp()
-        print("Illegal Upload Title:", self.title, now)
+        LOGGER.debug("Illegal Upload Title: %s %s", self.title, now)
         with open(RKVST_SBOM_PATH, "rb") as fd:
             with self.assertRaises(ArchivistBadRequestError):
                 metadata = self.arch.sboms.upload(
@@ -104,7 +103,7 @@ class TestSBOM(TestCase):
         Test sbom upload with spdx
         """
         now = now_timestamp()
-        print("SPDX Upload Title:", self.title, now)
+        LOGGER.debug("SPDX Upload Title: %s %s", self.title, now)
         with open(RKVST_SBOM_SPDX_PATH, "rb") as fd:
             metadata = self.arch.sboms.upload(
                 fd,
@@ -115,11 +114,11 @@ class TestSBOM(TestCase):
                     "version": "v0.0.1",
                 },
             )
-        print("first upload", json_dumps(metadata.dict(), indent=4))
+        LOGGER.debug("first upload %s", json_dumps(metadata.dict(), indent=4))
         identity = metadata.identity
 
         metadata1 = self.arch.sboms.read(identity)
-        print("read", json_dumps(metadata1.dict(), indent=4))
+        LOGGER.debug("read %s", json_dumps(metadata1.dict(), indent=4))
         self.assertEqual(
             metadata,
             metadata1,
@@ -131,7 +130,7 @@ class TestSBOM(TestCase):
         Test sbom upload with illegal format
         """
         now = now_timestamp()
-        print("SPDX Upload Title:", self.title, now)
+        LOGGER.debug("SPDX Upload Title: %s %s", self.title, now)
         with open(RKVST_SBOM_SPDX_PATH, "rb") as fd:
             with self.assertRaises(ArchivistBadRequestError):
                 metadata = self.arch.sboms.upload(
@@ -143,14 +142,14 @@ class TestSBOM(TestCase):
         Test sbom upload with confirmation
         """
         now = now_timestamp()
-        print("Confirmed Upload Title:", self.title, now)
+        LOGGER.debug("Confirmed Upload Title: %s %s", self.title, now)
         with open(RKVST_SBOM_PATH, "rb") as fd:
             metadata = self.arch.sboms.upload(fd, confirm=True)
-        print("first upload", json_dumps(metadata.dict(), indent=4))
+        LOGGER.debug("first upload %s", json_dumps(metadata.dict(), indent=4))
         identity = metadata.identity
 
         metadata1 = self.arch.sboms.read(identity)
-        print("read", json_dumps(metadata1.dict(), indent=4))
+        LOGGER.debug("read %s", json_dumps(metadata1.dict(), indent=4))
         self.assertEqual(
             metadata,
             metadata1,
@@ -170,16 +169,16 @@ class TestSBOM(TestCase):
         Test sbom upload with cyclonedx-xml
         """
         now = now_timestamp()
-        print("CycloneDX-XML Upload Title:", self.title, now)
+        LOGGER.debug("CycloneDX-XML Upload Title: %s %s", self.title, now)
         with open(RKVST_SBOM_PATH, "rb") as fd:
             metadata = self.arch.sboms.upload(
                 fd, params={"sbomType": "cyclonedx-xml"}, confirm=True
             )
-        print("first upload", json_dumps(metadata.dict(), indent=4))
+        LOGGER.debug("first upload %s", json_dumps(metadata.dict(), indent=4))
         identity = metadata.identity
 
         metadata1 = self.arch.sboms.read(identity)
-        print("read", json_dumps(metadata1.dict(), indent=4))
+        LOGGER.debug("read %s", json_dumps(metadata1.dict(), indent=4))
         self.assertEqual(
             metadata,
             metadata1,
@@ -199,21 +198,21 @@ class TestSBOM(TestCase):
         Test sbom upload and download through the SDK
         """
         now = now_timestamp()
-        print("Title:", self.title, now)
+        LOGGER.debug("Title: %s %s", self.title, now)
         with open(RKVST_SBOM_PATH, "rb") as fd:
             metadata = self.arch.sboms.upload(fd, confirm=True)
 
-        print("first upload", json_dumps(metadata.dict(), indent=4))
+        LOGGER.debug("first upload %s", json_dumps(metadata.dict(), indent=4))
         identity = metadata.identity
         with open(RKVST_SBOM_DOWNLOAD_PATH, "wb") as fd:
             sbom = self.arch.sboms.download(identity, fd)
 
-        print("sbom", sbom)
+        LOGGER.debug("sbom %s", sbom)
         clear_cache()
         self.assertTrue(cmp(RKVST_SBOM_PATH, RKVST_SBOM_DOWNLOAD_PATH, shallow=False))
 
         metadata1 = self.arch.sboms.read(identity)
-        print("read", json_dumps(metadata1.dict(), indent=4))
+        LOGGER.debug("read %s", json_dumps(metadata1.dict(), indent=4))
         self.assertEqual(
             metadata,
             metadata1,
@@ -234,17 +233,17 @@ class TestSBOM(TestCase):
         )
 
         for i, m in enumerate(metadatas):
-            print(i, ":", json_dumps(m.dict(), indent=4))
+            LOGGER.debug("%d: %s", i, json_dumps(m.dict(), indent=4))
 
         metadata2 = self.arch.sboms.publish(identity, confirm=True)
-        print("publish", json_dumps(metadata2.dict(), indent=4))
+        LOGGER.debug("publish %s", json_dumps(metadata2.dict(), indent=4))
         self.assertNotEqual(
             metadata1.published_date,
             metadata2.published_date,
             msg="Published_date not correct",
         )
         metadata3 = self.arch.sboms.publish(identity, confirm=True)
-        print("publish again", json_dumps(metadata3.dict(), indent=4))
+        LOGGER.debug("publish again %s", json_dumps(metadata3.dict(), indent=4))
         self.assertEqual(
             metadata2.published_date,
             metadata3.published_date,
@@ -252,7 +251,7 @@ class TestSBOM(TestCase):
         )
 
         metadata4 = self.arch.sboms.withdraw(identity, confirm=True)
-        print("withdraw", json_dumps(metadata4.dict(), indent=4))
+        LOGGER.debug("withdraw %s", json_dumps(metadata4.dict(), indent=4))
         self.assertNotEqual(
             metadata3.withdrawn_date,
             metadata4.withdrawn_date,
@@ -265,7 +264,7 @@ class TestSBOM(TestCase):
         )
 
         metadata5 = self.arch.sboms.withdraw(identity, confirm=True)
-        print("withdraw again", json_dumps(metadata5.dict(), indent=4))
+        LOGGER.debug("withdraw again %s", json_dumps(metadata5.dict(), indent=4))
         self.assertEqual(
             metadata4.withdrawn_date,
             metadata5.withdrawn_date,
@@ -282,4 +281,4 @@ class TestSBOM(TestCase):
             )
         )
         for i, m in enumerate(metadatas):
-            print(i, ":", json_dumps(m.dict(), indent=4))
+            LOGGER.debug("%d: %s", i, json_dumps(m.dict(), indent=4))

--- a/functests/execsubjects.py
+++ b/functests/execsubjects.py
@@ -3,7 +3,6 @@ Test subjects
 """
 from json import dumps as json_dumps
 from os import getenv
-from unittest import TestCase
 from uuid import uuid4
 
 from archivist.archivist import Archivist
@@ -15,10 +14,10 @@ from archivist.utils import get_auth
 
 from archivist import logger
 
-if getenv("RKVST_DEBUG") is not None:
-    logger.set_logger(getenv("RKVST_DEBUG"))
-else:
-    logger.set_logger("INFO")
+from .constants import TestCase
+
+if getenv("RKVST_LOGLEVEL") is not None:
+    logger.set_logger(getenv("RKVST_LOGLEVEL"))
 
 LOGGER = logger.LOGGER
 
@@ -89,7 +88,7 @@ class TestSubjects(TestCase):
                 "subject_string": SUBJECT_STRING,
             }
         )
-        print("subject:", json_dumps(subject, indent=4))
+        LOGGER.debug("subject: %s", json_dumps(subject, indent=4))
         self.assertEqual(
             subject["display_name"],
             self.display_name,
@@ -152,7 +151,7 @@ class TestSubjects(TestCase):
         """
         subjects = list(self.arch.subjects.list())
         for i, subject in enumerate(subjects):
-            print(i, ":", json_dumps(subject, indent=4))
+            LOGGER.debug("%d: %s", i, json_dumps(subject, indent=4))
 
         for subject in subjects:
             self.assertGreater(

--- a/functests/test_resources/door_entry_story.yaml
+++ b/functests/test_resources/door_entry_story.yaml
@@ -86,7 +86,7 @@ steps:
   - step:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create a door in Paris at Courts of Justice
-      print_response: true
+      LOGGER.debug_response: true
       asset_label: Courts of Justice Paris Front Door
     selector:
       - attributes:
@@ -262,7 +262,7 @@ steps:
       action: ASSETS_CREATE_IF_NOT_EXISTS
       description: Create Access Card 2
       asset_label: Access Card 2
-      print_response: true
+      LOGGER.debug_response: true
     selector:
       - attributes:
         - arc_display_name
@@ -341,7 +341,7 @@ steps:
       action: EVENTS_CREATE
       description: Courts of justice front door opened with card 2
       asset_label: Courts of Justice Paris Front Door
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     principal_declared:
@@ -364,7 +364,7 @@ steps:
       action: EVENTS_CREATE
       description: Access Card 2 opens Courts of justice front door
       asset_label: Access Card 2
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     principal_declared:
@@ -386,7 +386,7 @@ steps:
   - step:
       action: ASSETS_LIST
       description: List all doors
-      print_response: true
+      LOGGER.debug_response: true
     attrs:
       arc_display_type: door
       arc_namespace: !ENV ${RKVST_UNIQUE_ID:namespace}
@@ -394,7 +394,7 @@ steps:
   - step:
       action: ASSETS_LIST
       description: List all cards
-      print_response: true
+      LOGGER.debug_response: true
     attrs:
       arc_display_type: card
       arc_namespace: !ENV ${RKVST_UNIQUE_ID:namespace}
@@ -402,11 +402,11 @@ steps:
   - step:
       action: EVENTS_LIST
       description: List all events for Courts of Justice Paris Front Door
-      print_response: true
+      LOGGER.debug_response: true
       asset_label: Courts of Justice Paris Front Door
 
   - step:
       action: EVENTS_LIST
       description: List all events for Access Card 2
-      print_response: true
+      LOGGER.debug_response: true
       asset_label: Access Card 2

--- a/functests/test_resources/dynamic_tolerance_story.yaml
+++ b/functests/test_resources/dynamic_tolerance_story.yaml
@@ -27,7 +27,7 @@ steps:
   - step:
       action: COMPLIANCE_POLICIES_CREATE
       description: Create a compliance policy that checks an EV pump maintenance requests are serviced within a reasonable time frame.
-      print_response: true
+      LOGGER.debug_response: true
       delete: true
     description: ev maintenance policy
     display_name: ev maintenance policy

--- a/functests/test_resources/richness_story.yaml
+++ b/functests/test_resources/richness_story.yaml
@@ -56,7 +56,7 @@ steps:
   - step:
       action: COMPLIANCE_POLICIES_CREATE
       description: Create a compliance policy that checks the radiation level of radiation bags is less than 7 rads.
-      print_response: true
+      LOGGER.debug_response: true
       delete: true
     description: radiation level safety policy
     display_name: radiation safety policy
@@ -70,7 +70,7 @@ steps:
   - step:
       action: COMPLIANCE_POLICIES_CREATE
       description: Create a compliance policy that checks the weight of a radiation bag is less than or equal to 10kg.
-      print_response: true
+      LOGGER.debug_response: true
       delete: true
     description: weight level safety policy
     display_name: weight safety policy
@@ -126,7 +126,7 @@ steps:
   - step:
       action: COMPLIANCE_COMPLIANT_AT
       description: Check Compliance of bag 1.
-      print_response: True
+      LOGGER.debug_response: True
       asset_label: radiation bag 1
 
   - step:

--- a/functests/test_resources/sbom_story.yaml
+++ b/functests/test_resources/sbom_story.yaml
@@ -39,7 +39,7 @@ steps:
       action: EVENTS_CREATE
       description: Release YYYYMMDD.1 of Test SBOM for YAML story
       asset_label: ACME Corporation Detector SAAS
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     confirm: true
@@ -57,7 +57,7 @@ steps:
       action: EVENTS_CREATE
       description: Release YYYYMMDD.2 of Test SBOM for YAML story
       asset_label: ACME Corporation Detector SAAS
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     confirm: true
@@ -75,7 +75,7 @@ steps:
       action: EVENTS_CREATE
       description: Release YYYYMMDD.3 of Test SBOM for YAML story
       asset_label: ACME Corporation Detector SAAS
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     confirm: true
@@ -91,7 +91,7 @@ steps:
   - step:
       action: ASSETS_LIST
       description: List all sboms
-      print_response: true
+      LOGGER.debug_response: true
     attrs:
       arc_display_type: Software Package
       arc_namespace: !ENV ${RKVST_UNIQUE_ID:namespace}
@@ -99,7 +99,7 @@ steps:
   - step:
       action: EVENTS_LIST
       description: List all releases for this sbom
-      print_response: true
+      LOGGER.debug_response: true
       asset_label: ACME Corporation Detector SAAS
     props:
       confirmation_status: CONFIRMED

--- a/functests/test_resources/subjects_story.yaml
+++ b/functests/test_resources/subjects_story.yaml
@@ -3,7 +3,7 @@ steps:
   - step:
       action: SUBJECTS_CREATE
       description: Create a subjects entity.
-      print_response: true
+      LOGGER.debug_response: true
       subject_label: A subject
     display_name: A subject
     wallet_pub_key:
@@ -14,7 +14,7 @@ steps:
   - step:
       action: SUBJECTS_CREATE_FROM_B64
       description: Import a subjects entity.
-      print_response: true
+      LOGGER.debug_response: true
       subject_label: An imported subject
     display_name: An imported subject
     subject_string: >-
@@ -33,23 +33,23 @@ steps:
   - step:
       action: SUBJECTS_COUNT
       description: Count all subjects
-      print_response: true
+      LOGGER.debug_response: true
 
   - step:
       action: SUBJECTS_LIST
       description: List all subjects
-      print_response: true
+      LOGGER.debug_response: true
 
   - step:
       action: SUBJECTS_READ
       description: Read subject
-      print_response: true
+      LOGGER.debug_response: true
       subject_label: A subject
 
   - step:
       action: SUBJECTS_UPDATE
       description: Update a subjects entity.
-      print_response: true
+      LOGGER.debug_response: true
       subject_label: A subject
     wallet_pub_key:
       - 04c1173bf7844bf1c607b79c18db091b9558ffe581bf132b8cf3b37657230fa321a0880b54a79a88b28bc710ede6dcf3d8272c5210bfd41ea83188e385d12c189c
@@ -57,11 +57,11 @@ steps:
   - step:
       action: SUBJECTS_DELETE
       description: Delete subject
-      print_response: true
+      LOGGER.debug_response: true
       subject_label: A subject
 
   - step:
       action: SUBJECTS_DELETE
       description: Delete subject
-      print_response: true
+      LOGGER.debug_response: true
       subject_label: An imported subject

--- a/functests/test_resources/synsation_story.yaml.j2
+++ b/functests/test_resources/synsation_story.yaml.j2
@@ -1,7 +1,7 @@
 ---
 # The step field is a string that represents the method bound to an endpoint.
 #
-# Create a number of offices equipped with printers, coffee machines and security
+# Create a number of offices equipped with LOGGER.debugers, coffee machines and security
 # cameras
 #
 steps:
@@ -32,14 +32,14 @@ steps:
   - step:
       action: LOCATIONS_COUNT
       description: Count locations in namespace
-      print_response: true
+      LOGGER.debug_response: true
     attrs:
       namespace: "{{ env['RKVST_UNIQUE_ID'] or 'namespace' }}"
 
   - step:
       action: LOCATIONS_LIST
       description: List locations in namespace
-      print_response: true
+      LOGGER.debug_response: true
     attrs:
       namespace: "{{ env['RKVST_UNIQUE_ID'] or 'namespace' }}"
 
@@ -73,22 +73,22 @@ steps:
   - step:
       action: ASSETS_WAIT_FOR_CONFIRMED
       description: Wait for all assets to be confirmed
-      print_response: true
+      LOGGER.debug_response: true
     attrs:
       arc_namespace: "{{ env['RKVST_UNIQUE_ID'] or 'namespace' }}"
 
   - step:
       action: ASSETS_LIST
-      description: List all printers
-      print_response: true
+      description: List all LOGGER.debugers
+      LOGGER.debug_response: true
     attrs:
-      arc_display_type: printer
+      arc_display_type: LOGGER.debuger
       arc_namespace: "{{ env['RKVST_UNIQUE_ID'] or 'namespace' }}"
 
   - step:
       action: ASSETS_LIST
       description: List all coffee machines
-      print_response: true
+      LOGGER.debug_response: true
     attrs:
       arc_display_type: coffee machine
       arc_namespace: "{{ env['RKVST_UNIQUE_ID'] or 'namespace' }}"
@@ -96,7 +96,7 @@ steps:
   - step:
       action: ASSETS_LIST
       description: List all security cameras
-      print_response: true
+      LOGGER.debug_response: true
     attrs:
       arc_display_type: security camera
       arc_namespace: "{{ env['RKVST_UNIQUE_ID'] or 'namespace' }}"

--- a/functests/test_resources/wipp_story.yaml
+++ b/functests/test_resources/wipp_story.yaml
@@ -55,7 +55,7 @@ steps:
       action: EVENTS_CREATE
       description: Characterize Drum 1
       asset_label: Drum 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -80,7 +80,7 @@ steps:
       action: EVENTS_CREATE
       description: Tomograph Drum 1
       asset_label: Drum 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -106,7 +106,7 @@ steps:
       action: EVENTS_CREATE
       description: Loading Drum 1 into Cask 1
       asset_label: Drum 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -125,7 +125,7 @@ steps:
       action: EVENTS_CREATE
       description: Filled Cask 1 with Drum 1
       asset_label: Cask 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -144,7 +144,7 @@ steps:
       action: EVENTS_CREATE
       description: Preship inspection of Drum 1
       asset_label: Drum 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -161,7 +161,7 @@ steps:
       action: EVENTS_CREATE
       description: Preship inspection of Cask 1
       asset_label: Cask 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -178,7 +178,7 @@ steps:
       action: EVENTS_CREATE
       description: Departure of Drum 1
       asset_label: Drum 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -198,7 +198,7 @@ steps:
       action: EVENTS_CREATE
       description: Departure of Cask 1
       asset_label: Cask 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -219,7 +219,7 @@ steps:
       action: EVENTS_CREATE
       description: Atlanta Waypoint of Cask 1
       asset_label: Cask 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -249,7 +249,7 @@ steps:
       action: EVENTS_CREATE
       description: Talladega Waypoint of Cask 1
       asset_label: Cask 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -280,7 +280,7 @@ steps:
       action: EVENTS_CREATE
       description: Arrival of Drum 1
       asset_label: Drum 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -297,7 +297,7 @@ steps:
       action: EVENTS_CREATE
       description: Arrival of Cask 1
       asset_label: Cask 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -315,7 +315,7 @@ steps:
       action: EVENTS_CREATE
       description: Unloading Drum 1 from Cask 1
       asset_label: Drum 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -332,7 +332,7 @@ steps:
       action: EVENTS_CREATE
       description: Unloading Drum 1 from Cask 1
       asset_label: Cask 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:
@@ -350,7 +350,7 @@ steps:
       action: EVENTS_CREATE
       description: Drum 1 Emplacemant
       asset_label: Drum 1
-      print_response: true
+      LOGGER.debug_response: true
     operation: Record
     behaviour: RecordEvidence
     event_attributes:

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -28,7 +28,7 @@ docker run \
     -e RKVST_APPREG_CLIENT \
     -e RKVST_APPREG_SECRET \
     -e RKVST_APPREG_SECRET_FILENAME \
-    -e RKVST_DEBUG \
+    -e RKVST_LOGLEVEL \
     -e RKVST_REFRESH_TOKEN \
     -e GITHUB_REF \
     rkvst-python-builder \

--- a/scripts/functests.sh
+++ b/scripts/functests.sh
@@ -60,4 +60,4 @@ then
     exit 0
 fi
 
-python3 -m unittest discover -v -p exec*.py -s functests
+python3 -m unittest discover -v -p exec*.py -t . -s functests

--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -23,8 +23,8 @@ from .mock_response import MockResponse
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 
 RKVST_APPREG_CLIENT = "client_id-2f78-4fa0-9425-d59314845bc5"

--- a/unittests/testarchivistlist.py
+++ b/unittests/testarchivistlist.py
@@ -21,8 +21,8 @@ from .testarchivist import TestArchivistMethods
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 
 class TestArchivistList(TestArchivistMethods):

--- a/unittests/testarchivistsignature.py
+++ b/unittests/testarchivistsignature.py
@@ -20,8 +20,8 @@ from .testarchivist import TestArchivistMethods
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 
 class TestArchivistSignature(TestArchivistMethods):

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -52,8 +52,8 @@ from .testassetsconstants import (
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testassetslist.py
+++ b/unittests/testassetslist.py
@@ -23,8 +23,8 @@ from .testassetsconstants import (
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testassetsread.py
+++ b/unittests/testassetsread.py
@@ -38,8 +38,8 @@ RESPONSE_BAD_PUBLICURL = {
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testassetswait.py
+++ b/unittests/testassetswait.py
@@ -28,8 +28,8 @@ from .testassetsconstants import (
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testcompliance.py
+++ b/unittests/testcompliance.py
@@ -56,8 +56,8 @@ POLICY = {
     "time_period_seconds": 10,
 }
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testpublic.py
+++ b/unittests/testpublic.py
@@ -22,8 +22,8 @@ from .mock_response import MockResponse
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 
 class TestPublic(TestCase):

--- a/unittests/testpublicassetattachments.py
+++ b/unittests/testpublicassetattachments.py
@@ -21,8 +21,8 @@ from .mock_response import MockResponse
 
 # pylint: disable=protected-access
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testpublicassets.py
+++ b/unittests/testpublicassets.py
@@ -13,8 +13,8 @@ from archivist.logger import set_logger
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testpublicassetsread.py
+++ b/unittests/testpublicassetsread.py
@@ -26,8 +26,8 @@ from .testpublicassets import (
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testpublicevents.py
+++ b/unittests/testpublicevents.py
@@ -24,8 +24,8 @@ from .testeventsconstants import (
 from .mock_response import MockResponse
 from .testevents import IDENTITY
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunner.py
+++ b/unittests/testrunner.py
@@ -17,8 +17,8 @@ from archivist.constants import ASSET_BEHAVIOURS
 from archivist.logger import set_logger
 from archivist.runner import tree
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunneractiomap.py
+++ b/unittests/testrunneractiomap.py
@@ -15,8 +15,8 @@ from archivist.archivist import Archivist
 from archivist.runner import _ActionMap
 from archivist.logger import set_logger
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunnerassets.py
+++ b/unittests/testrunnerassets.py
@@ -18,8 +18,8 @@ from archivist.errors import ArchivistInvalidOperationError
 from archivist.events import Event
 from archivist.logger import set_logger
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunnercompliance.py
+++ b/unittests/testrunnercompliance.py
@@ -16,8 +16,8 @@ from archivist.compliance import Compliance
 from archivist.compliance_policies import CompliancePolicy
 from archivist.logger import set_logger
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunnerlocation.py
+++ b/unittests/testrunnerlocation.py
@@ -19,8 +19,8 @@ from archivist.constants import (
 
 from archivist.logger import set_logger
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testrunnerstep.py
+++ b/unittests/testrunnerstep.py
@@ -17,8 +17,8 @@ from archivist.logger import set_logger
 ASSET_ID = "assets/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
 LOCATION_ID = "locations/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -29,8 +29,8 @@ from .mock_response import MockResponse
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 IDENTITY = f"{SBOMS_LABEL}/c3da0d3a-32bf-4f5f-a8c6-b342a8356480"
 PROPS = {

--- a/unittests/testsubjects.py
+++ b/unittests/testsubjects.py
@@ -18,8 +18,8 @@ from archivist.logger import set_logger
 
 from .mock_response import MockResponse
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access

--- a/unittests/testtenancies.py
+++ b/unittests/testtenancies.py
@@ -29,8 +29,8 @@ RESPONSE_PUBLICINFO = {
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
 
-if "RKVST_DEBUG" in environ and environ["RKVST_DEBUG"]:
-    set_logger(environ["RKVST_DEBUG"])
+if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
+    set_logger(environ["RKVST_LOGLEVEL"])
 
 LOGGER = getLogger(__name__)
 


### PR DESCRIPTION
Problem:
The functional tests used print() instead of LOGGER to output progress.

Solution:
Converted all print() to LOGGER.debug and rename RKVST_DEBUG environment variable to RKVST_LOGLEVEL.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>