### PR TITLE
Use jupyter notebooks on local desktop

### DIFF
--- a/archivist/notebooks/.gitignore
+++ b/archivist/notebooks/.gitignore
@@ -1,1 +1,2 @@
+*.env
 .ipynb_checkpoints/

--- a/archivist/notebooks/Check Asset Compliance using CURRENT OUTSTANDING Policy.ipynb
+++ b/archivist/notebooks/Check Asset Compliance using CURRENT OUTSTANDING Policy.ipynb
@@ -35,6 +35,8 @@
     "from uuid import uuid4\n",
     "from warnings import filterwarnings\n",
     "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
     "from archivist.archivist import Archivist\n",
     "from archivist.compliance_policy_requests import CompliancePolicyCurrentOutstanding\n",
     "from archivist.constants import ASSET_BEHAVIOURS\n",
@@ -47,6 +49,17 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "e4b24e8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext dotenv\n",
+    "%dotenv -o notebooks.env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "92835114",
    "metadata": {},
    "outputs": [],
@@ -57,13 +70,13 @@
     "# CLIENT = represents the client ID from an Application Registration\n",
     "# SECRET = represents the client secret from an Application Registration\n",
     "RKVST_URL = getenv(\"RKVST_URL\")\n",
-    "APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
-    "APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")"
+    "RKVST_APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "RKVST_APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "d85dcf4c",
    "metadata": {},
    "outputs": [
@@ -72,7 +85,7 @@
      "output_type": "stream",
      "text": [
       "Connecting to RKVST\n",
-      "URL https://app.dev-paul-0.wild.jitsuin.io\n"
+      "RKVST_URL https://app.rkvst.io\n"
      ]
     }
    ],
@@ -92,13 +105,13 @@
     "\n",
     "# Initialize connection to RKVST\n",
     "print(\"Connecting to RKVST\")\n",
-    "print(\"URL\", RKVST_URL)\n",
-    "arch = Archivist(RKVST_URL, (APPREG_CLIENT, APPREG_SECRET), max_time=300)"
+    "print(\"RKVST_URL\", RKVST_URL)\n",
+    "arch = Archivist(RKVST_URL, (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET), max_time=300)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "acdf240c",
    "metadata": {},
    "outputs": [],
@@ -128,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "8889c68d",
    "metadata": {},
    "outputs": [],
@@ -164,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "ba24d143",
    "metadata": {},
    "outputs": [],
@@ -191,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "bde8fc72",
    "metadata": {},
    "outputs": [],
@@ -218,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "b7482420",
    "metadata": {
     "scrolled": true
@@ -228,7 +241,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Tag for this run: 81c94ed1-e310-4743-8e39-9ee0a9170bdf\n"
+      "Tag for this run: 5597da73-19e4-448b-80c0-33c79253961a\n"
      ]
     }
    ],
@@ -244,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "bb5b0651",
    "metadata": {},
    "outputs": [
@@ -260,7 +273,7 @@
      "output_type": "stream",
      "text": [
       "CURRENT_OUTSTANDING_POLICY: {\n",
-      "    \"identity\": \"compliance_policies/159b05e9-5d9d-4642-b0ed-db6c1274a979\",\n",
+      "    \"identity\": \"compliance_policies/253a31f2-ef9f-44ba-8940-4dafd23e32f9\",\n",
       "    \"compliance_type\": \"COMPLIANCE_CURRENT_OUTSTANDING\",\n",
       "    \"description\": \"Vault doors should be closed according to site security policy section Phys.Integ.02\",\n",
       "    \"display_name\": \"Phys.Integ.02\",\n",
@@ -279,7 +292,7 @@
       "    \"richness_assertions\": []\n",
       "}\n",
       "compliance_policy {\n",
-      "    \"identity\": \"compliance_policies/159b05e9-5d9d-4642-b0ed-db6c1274a979\",\n",
+      "    \"identity\": \"compliance_policies/253a31f2-ef9f-44ba-8940-4dafd23e32f9\",\n",
       "    \"compliance_type\": \"COMPLIANCE_CURRENT_OUTSTANDING\",\n",
       "    \"description\": \"Vault doors should be closed according to site security policy section Phys.Integ.02\",\n",
       "    \"display_name\": \"Phys.Integ.02\",\n",
@@ -308,7 +321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "f8ac6dda",
    "metadata": {},
    "outputs": [
@@ -324,50 +337,50 @@
      "output_type": "stream",
      "text": [
       "DOOR: {\n",
-      "    \"identity\": \"assets/6ef99260-65ae-48b7-9cda-e1c60f3ce79d\",\n",
+      "    \"identity\": \"assets/652b3fdf-736e-455f-81ec-fed5088a351c\",\n",
       "    \"behaviours\": [\n",
-      "        \"Builtin\",\n",
       "        \"AssetCreator\",\n",
       "        \"Attachments\",\n",
-      "        \"RecordEvidence\"\n",
+      "        \"RecordEvidence\",\n",
+      "        \"Builtin\"\n",
       "    ],\n",
       "    \"attributes\": {\n",
-      "        \"arc_description\": \"Main door to the second level security vault in Gringott's Wizarding Bank\",\n",
       "        \"arc_display_name\": \"Gringott's Vault 2\",\n",
-      "        \"arc_display_type\": \"Vault Door\"\n",
+      "        \"arc_display_type\": \"Vault Door\",\n",
+      "        \"arc_description\": \"Main door to the second level security vault in Gringott's Wizarding Bank\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"tracked\": \"TRACKED\",\n",
-      "    \"owner\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"at_time\": \"2023-01-10T16:19:32Z\",\n",
+      "    \"owner\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"at_time\": \"2023-01-16T11:51:30Z\",\n",
       "    \"storage_integrity\": \"TENANT_STORAGE\",\n",
       "    \"proof_mechanism\": \"SIMPLE_HASH\",\n",
-      "    \"chain_id\": \"99\",\n",
+      "    \"chain_id\": \"827586838445807967\",\n",
       "    \"public\": false,\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n",
       "gringotts_vault {\n",
-      "    \"identity\": \"assets/6ef99260-65ae-48b7-9cda-e1c60f3ce79d\",\n",
+      "    \"identity\": \"assets/652b3fdf-736e-455f-81ec-fed5088a351c\",\n",
       "    \"behaviours\": [\n",
-      "        \"Builtin\",\n",
       "        \"AssetCreator\",\n",
       "        \"Attachments\",\n",
-      "        \"RecordEvidence\"\n",
+      "        \"RecordEvidence\",\n",
+      "        \"Builtin\"\n",
       "    ],\n",
       "    \"attributes\": {\n",
-      "        \"arc_description\": \"Main door to the second level security vault in Gringott's Wizarding Bank\",\n",
       "        \"arc_display_name\": \"Gringott's Vault 2\",\n",
-      "        \"arc_display_type\": \"Vault Door\"\n",
+      "        \"arc_display_type\": \"Vault Door\",\n",
+      "        \"arc_description\": \"Main door to the second level security vault in Gringott's Wizarding Bank\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"tracked\": \"TRACKED\",\n",
-      "    \"owner\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"at_time\": \"2023-01-10T16:19:32Z\",\n",
+      "    \"owner\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"at_time\": \"2023-01-16T11:51:30Z\",\n",
       "    \"storage_integrity\": \"TENANT_STORAGE\",\n",
       "    \"proof_mechanism\": \"SIMPLE_HASH\",\n",
-      "    \"chain_id\": \"99\",\n",
+      "    \"chain_id\": \"827586838445807967\",\n",
       "    \"public\": false,\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n"
      ]
     }
@@ -381,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "d93be01f",
    "metadata": {},
    "outputs": [
@@ -390,49 +403,49 @@
      "output_type": "stream",
      "text": [
       "DOOR_OPENED: {\n",
-      "    \"identity\": \"assets/6ef99260-65ae-48b7-9cda-e1c60f3ce79d/events/2c5dd3b7-67a6-4f4a-bb68-59b9eb2a70cb\",\n",
-      "    \"asset_identity\": \"assets/6ef99260-65ae-48b7-9cda-e1c60f3ce79d\",\n",
+      "    \"identity\": \"assets/652b3fdf-736e-455f-81ec-fed5088a351c/events/f4355906-bd65-4d3a-b726-4967936012dd\",\n",
+      "    \"asset_identity\": \"assets/652b3fdf-736e-455f-81ec-fed5088a351c\",\n",
       "    \"event_attributes\": {\n",
       "        \"arc_display_type\": \"Open\",\n",
-      "        \"arc_correlation_value\": \"81c94ed1-e310-4743-8e39-9ee0a9170bdf\",\n",
+      "        \"arc_correlation_value\": \"5597da73-19e4-448b-80c0-33c79253961a\",\n",
       "        \"arc_description\": \"Open the door for Lucius Malfoy\"\n",
       "    },\n",
       "    \"asset_attributes\": {},\n",
       "    \"operation\": \"Record\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
-      "    \"timestamp_declared\": \"2023-01-10T16:19:36Z\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:19:36Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:19:36.508165839Z\",\n",
+      "    \"timestamp_declared\": \"2023-01-16T11:51:36Z\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:51:36Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:51:36.744394895Z\",\n",
       "    \"principal_declared\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"principal_accepted\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"block_number\": 0,\n",
       "    \"transaction_index\": 0,\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n",
       "COMPLIANCE (should be false): {\n",
       "    \"compliant\": false,\n",
       "    \"compliance\": [\n",
       "        {\n",
-      "            \"compliance_policy_identity\": \"compliance_policies/159b05e9-5d9d-4642-b0ed-db6c1274a979\",\n",
+      "            \"compliance_policy_identity\": \"compliance_policies/253a31f2-ef9f-44ba-8940-4dafd23e32f9\",\n",
       "            \"compliant\": false,\n",
       "            \"reason\": \"No closing event for Open\"\n",
       "        }\n",
       "    ],\n",
       "    \"next_page_token\": \"\",\n",
-      "    \"compliant_at\": \"2023-01-10T16:19:42Z\"\n",
+      "    \"compliant_at\": \"2023-01-16T11:51:42Z\"\n",
       "}\n"
      ]
     }
@@ -451,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "6e304daa",
    "metadata": {},
    "outputs": [
@@ -460,49 +473,49 @@
      "output_type": "stream",
      "text": [
       "DOOR_CLOSED: {\n",
-      "    \"identity\": \"assets/6ef99260-65ae-48b7-9cda-e1c60f3ce79d/events/1d9cc38b-3c1d-4cb6-aa7f-42d463fe99d1\",\n",
-      "    \"asset_identity\": \"assets/6ef99260-65ae-48b7-9cda-e1c60f3ce79d\",\n",
+      "    \"identity\": \"assets/652b3fdf-736e-455f-81ec-fed5088a351c/events/e1d5c641-c1a4-4a8c-b07b-621ff054e86c\",\n",
+      "    \"asset_identity\": \"assets/652b3fdf-736e-455f-81ec-fed5088a351c\",\n",
       "    \"event_attributes\": {\n",
-      "        \"arc_correlation_value\": \"81c94ed1-e310-4743-8e39-9ee0a9170bdf\",\n",
+      "        \"arc_correlation_value\": \"5597da73-19e4-448b-80c0-33c79253961a\",\n",
       "        \"arc_description\": \"Closed the door after Lucius Malfoy exited the vault\",\n",
       "        \"arc_display_type\": \"Close\"\n",
       "    },\n",
       "    \"asset_attributes\": {},\n",
       "    \"operation\": \"Record\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
-      "    \"timestamp_declared\": \"2023-01-10T16:19:47Z\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:19:47Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:19:47.541462429Z\",\n",
+      "    \"timestamp_declared\": \"2023-01-16T11:51:42Z\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:51:42Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:51:42.809012247Z\",\n",
       "    \"principal_declared\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"principal_accepted\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"block_number\": 0,\n",
       "    \"transaction_index\": 0,\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n",
       "COMPLIANCE (should be true): {\n",
       "    \"compliant\": true,\n",
       "    \"compliance\": [\n",
       "        {\n",
-      "            \"compliance_policy_identity\": \"compliance_policies/159b05e9-5d9d-4642-b0ed-db6c1274a979\",\n",
+      "            \"compliance_policy_identity\": \"compliance_policies/253a31f2-ef9f-44ba-8940-4dafd23e32f9\",\n",
       "            \"compliant\": true,\n",
       "            \"reason\": \"\"\n",
       "        }\n",
       "    ],\n",
       "    \"next_page_token\": \"\",\n",
-      "    \"compliant_at\": \"2023-01-10T16:19:53Z\"\n",
+      "    \"compliant_at\": \"2023-01-16T11:51:49Z\"\n",
       "}\n"
      ]
     }
@@ -521,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "2edac120",
    "metadata": {},
    "outputs": [
@@ -533,13 +546,13 @@
       "    \"compliant\": false,\n",
       "    \"compliance\": [\n",
       "        {\n",
-      "            \"compliance_policy_identity\": \"compliance_policies/159b05e9-5d9d-4642-b0ed-db6c1274a979\",\n",
+      "            \"compliance_policy_identity\": \"compliance_policies/253a31f2-ef9f-44ba-8940-4dafd23e32f9\",\n",
       "            \"compliant\": false,\n",
       "            \"reason\": \"No closing event for Open\"\n",
       "        }\n",
       "    ],\n",
       "    \"next_page_token\": \"\",\n",
-      "    \"compliant_at\": \"2023-01-10T16:19:42Z\"\n",
+      "    \"compliant_at\": \"2023-01-16T11:51:42Z\"\n",
       "}\n"
      ]
     }
@@ -563,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "40ffc716",
    "metadata": {},
    "outputs": [],
@@ -573,6 +586,14 @@
     "    compliance_policy[\"identity\"],\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9aed548",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -591,7 +612,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/archivist/notebooks/Check Asset Compliance using SINCE Policy.ipynb
+++ b/archivist/notebooks/Check Asset Compliance using SINCE Policy.ipynb
@@ -37,6 +37,8 @@
     "from uuid import uuid4\n",
     "from warnings import filterwarnings\n",
     "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
     "from archivist.archivist import Archivist\n",
     "from archivist.compliance_policy_requests import (\n",
     "    CompliancePolicySince,\n",
@@ -49,6 +51,17 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "96987aaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext dotenv\n",
+    "%dotenv -o notebooks.env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "a877ffed",
    "metadata": {},
    "outputs": [],
@@ -59,13 +72,13 @@
     "# CLIENT = represents the client ID from an Application Registration\n",
     "# SECRET = represents the client secret from an Application Registration\n",
     "RKVST_URL = getenv(\"RKVST_URL\")\n",
-    "APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
-    "APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")"
+    "RKVST_APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "RKVST_APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "3fdc8e16",
    "metadata": {},
    "outputs": [
@@ -74,7 +87,7 @@
      "output_type": "stream",
      "text": [
       "Connecting to RKVST\n",
-      "URL https://app.dev-paul-0.wild.jitsuin.io\n"
+      "RKVST_URL https://app.rkvst.io\n"
      ]
     }
    ],
@@ -94,13 +107,13 @@
     "\n",
     "# Initialize connection to RKVST\n",
     "print(\"Connecting to RKVST\")\n",
-    "print(\"URL\", RKVST_URL)\n",
-    "arch = Archivist(RKVST_URL, (APPREG_CLIENT, APPREG_SECRET), max_time=300)"
+    "print(\"RKVST_URL\", RKVST_URL)\n",
+    "arch = Archivist(RKVST_URL, (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET), max_time=300)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "acdf240c",
    "metadata": {},
    "outputs": [],
@@ -131,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "8889c68d",
    "metadata": {},
    "outputs": [],
@@ -157,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "ba24d143",
    "metadata": {},
    "outputs": [],
@@ -183,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "b7482420",
    "metadata": {
     "scrolled": true
@@ -195,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "bb5b0651",
    "metadata": {},
    "outputs": [
@@ -211,7 +224,7 @@
      "output_type": "stream",
      "text": [
       "SINCE_POLICY: {\n",
-      "    \"identity\": \"compliance_policies/e9b458b7-5e08-41ce-bf4c-ff01b7975148\",\n",
+      "    \"identity\": \"compliance_policies/458957bc-4da7-4cc3-b37f-43fa53abe0cc\",\n",
       "    \"compliance_type\": \"COMPLIANCE_SINCE\",\n",
       "    \"description\": \"Maintenance should be performed every 10 seconds\",\n",
       "    \"display_name\": \"Regular Maintenance of Traffic light\",\n",
@@ -222,7 +235,7 @@
       "            ]\n",
       "        }\n",
       "    ],\n",
-      "    \"event_display_type\": \"Maintenance Performed 281b5ac5-764f-446d-84da-17138e18fde0\",\n",
+      "    \"event_display_type\": \"Maintenance Performed a3f86bbf-737a-45d8-bd84-3d6612fb641e\",\n",
       "    \"closing_event_display_type\": \"\",\n",
       "    \"time_period_seconds\": \"10\",\n",
       "    \"dynamic_window\": \"0\",\n",
@@ -230,7 +243,7 @@
       "    \"richness_assertions\": []\n",
       "}\n",
       "compliance_policy {\n",
-      "    \"identity\": \"compliance_policies/e9b458b7-5e08-41ce-bf4c-ff01b7975148\",\n",
+      "    \"identity\": \"compliance_policies/458957bc-4da7-4cc3-b37f-43fa53abe0cc\",\n",
       "    \"compliance_type\": \"COMPLIANCE_SINCE\",\n",
       "    \"description\": \"Maintenance should be performed every 10 seconds\",\n",
       "    \"display_name\": \"Regular Maintenance of Traffic light\",\n",
@@ -241,7 +254,7 @@
       "            ]\n",
       "        }\n",
       "    ],\n",
-      "    \"event_display_type\": \"Maintenance Performed 281b5ac5-764f-446d-84da-17138e18fde0\",\n",
+      "    \"event_display_type\": \"Maintenance Performed a3f86bbf-737a-45d8-bd84-3d6612fb641e\",\n",
       "    \"closing_event_display_type\": \"\",\n",
       "    \"time_period_seconds\": \"10\",\n",
       "    \"dynamic_window\": \"0\",\n",
@@ -260,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "f8ac6dda",
    "metadata": {},
    "outputs": [
@@ -269,12 +282,12 @@
      "output_type": "stream",
      "text": [
       "TRAFFIC_LIGHT: {\n",
-      "    \"identity\": \"assets/b961c23f-c1db-4bde-9ed3-c997378f2bf2\",\n",
+      "    \"identity\": \"assets/b6f63a6d-24a1-4dd8-a6d7-21e50e603ceb\",\n",
       "    \"behaviours\": [\n",
+      "        \"RecordEvidence\",\n",
       "        \"Builtin\",\n",
       "        \"AssetCreator\",\n",
-      "        \"Attachments\",\n",
-      "        \"RecordEvidence\"\n",
+      "        \"Attachments\"\n",
       "    ],\n",
       "    \"attributes\": {\n",
       "        \"arc_description\": \"Traffic flow control light at A603 North East\",\n",
@@ -283,21 +296,21 @@
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"tracked\": \"TRACKED\",\n",
-      "    \"owner\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"at_time\": \"2023-01-10T16:20:33Z\",\n",
+      "    \"owner\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"at_time\": \"2023-01-16T11:52:27Z\",\n",
       "    \"storage_integrity\": \"TENANT_STORAGE\",\n",
       "    \"proof_mechanism\": \"SIMPLE_HASH\",\n",
-      "    \"chain_id\": \"99\",\n",
+      "    \"chain_id\": \"827586838445807967\",\n",
       "    \"public\": false,\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n",
       "traffic_light {\n",
-      "    \"identity\": \"assets/b961c23f-c1db-4bde-9ed3-c997378f2bf2\",\n",
+      "    \"identity\": \"assets/b6f63a6d-24a1-4dd8-a6d7-21e50e603ceb\",\n",
       "    \"behaviours\": [\n",
+      "        \"RecordEvidence\",\n",
       "        \"Builtin\",\n",
       "        \"AssetCreator\",\n",
-      "        \"Attachments\",\n",
-      "        \"RecordEvidence\"\n",
+      "        \"Attachments\"\n",
       "    ],\n",
       "    \"attributes\": {\n",
       "        \"arc_description\": \"Traffic flow control light at A603 North East\",\n",
@@ -306,13 +319,13 @@
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"tracked\": \"TRACKED\",\n",
-      "    \"owner\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"at_time\": \"2023-01-10T16:20:33Z\",\n",
+      "    \"owner\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"at_time\": \"2023-01-16T11:52:27Z\",\n",
       "    \"storage_integrity\": \"TENANT_STORAGE\",\n",
       "    \"proof_mechanism\": \"SIMPLE_HASH\",\n",
-      "    \"chain_id\": \"99\",\n",
+      "    \"chain_id\": \"827586838445807967\",\n",
       "    \"public\": false,\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n"
      ]
     }
@@ -326,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "d93be01f",
    "metadata": {},
    "outputs": [
@@ -335,49 +348,49 @@
      "output_type": "stream",
      "text": [
       "MAINTENANCE_PERFORMED: {\n",
-      "    \"identity\": \"assets/b961c23f-c1db-4bde-9ed3-c997378f2bf2/events/433f4c4e-f6e2-43f6-a48c-0f15152a2734\",\n",
-      "    \"asset_identity\": \"assets/b961c23f-c1db-4bde-9ed3-c997378f2bf2\",\n",
+      "    \"identity\": \"assets/b6f63a6d-24a1-4dd8-a6d7-21e50e603ceb/events/eba5bb05-d4ff-4d99-9205-41236560d24d\",\n",
+      "    \"asset_identity\": \"assets/b6f63a6d-24a1-4dd8-a6d7-21e50e603ceb\",\n",
       "    \"event_attributes\": {\n",
       "        \"arc_description\": \"Maintenance performed on traffic light\",\n",
-      "        \"arc_display_type\": \"Maintenance Performed 281b5ac5-764f-446d-84da-17138e18fde0\"\n",
+      "        \"arc_display_type\": \"Maintenance Performed a3f86bbf-737a-45d8-bd84-3d6612fb641e\"\n",
       "    },\n",
       "    \"asset_attributes\": {},\n",
       "    \"operation\": \"Record\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
-      "    \"timestamp_declared\": \"2023-01-10T16:20:37Z\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:20:37Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:20:37.759462037Z\",\n",
+      "    \"timestamp_declared\": \"2023-01-16T11:52:31Z\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:52:31Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:52:31.599813432Z\",\n",
       "    \"principal_declared\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"principal_accepted\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"block_number\": 0,\n",
       "    \"transaction_index\": 0,\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n",
       "Sleep 1 second...\n",
       "COMPLIANCE (true): {\n",
       "    \"compliant\": true,\n",
       "    \"compliance\": [\n",
       "        {\n",
-      "            \"compliance_policy_identity\": \"compliance_policies/e9b458b7-5e08-41ce-bf4c-ff01b7975148\",\n",
+      "            \"compliance_policy_identity\": \"compliance_policies/458957bc-4da7-4cc3-b37f-43fa53abe0cc\",\n",
       "            \"compliant\": true,\n",
       "            \"reason\": \"\"\n",
       "        }\n",
       "    ],\n",
       "    \"next_page_token\": \"\",\n",
-      "    \"compliant_at\": \"2023-01-10T16:20:39Z\"\n",
+      "    \"compliant_at\": \"2023-01-16T11:52:33Z\"\n",
       "}\n"
      ]
     }
@@ -397,7 +410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "fe8e2a6e",
    "metadata": {},
    "outputs": [
@@ -410,13 +423,13 @@
       "    \"compliant\": false,\n",
       "    \"compliance\": [\n",
       "        {\n",
-      "            \"compliance_policy_identity\": \"compliance_policies/e9b458b7-5e08-41ce-bf4c-ff01b7975148\",\n",
+      "            \"compliance_policy_identity\": \"compliance_policies/458957bc-4da7-4cc3-b37f-43fa53abe0cc\",\n",
       "            \"compliant\": false,\n",
       "            \"reason\": \"Duration 20s exceeds limit 10s\"\n",
       "        }\n",
       "    ],\n",
       "    \"next_page_token\": \"\",\n",
-      "    \"compliant_at\": \"2023-01-10T16:20:58Z\"\n",
+      "    \"compliant_at\": \"2023-01-16T11:52:52Z\"\n",
       "}\n"
      ]
     }
@@ -434,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "40ffc716",
    "metadata": {},
    "outputs": [],
@@ -444,6 +457,14 @@
     "    compliance_policy[\"identity\"],\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bccec420",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -462,7 +483,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/archivist/notebooks/Create Asset and Events.ipynb
+++ b/archivist/notebooks/Create Asset and Events.ipynb
@@ -41,6 +41,8 @@
     "from os import getenv\n",
     "from warnings import filterwarnings\n",
     "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
     "from archivist.archivist import Archivist\n",
     "from archivist.proof_mechanism import ProofMechanism\n",
     "from archivist.logger import set_logger"
@@ -49,6 +51,17 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "d078b551",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext dotenv\n",
+    "%dotenv -o notebooks.env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "05c9e0bc",
    "metadata": {},
    "outputs": [],
@@ -59,8 +72,8 @@
     "# CLIENT = represents the client ID from an Application Registration\n",
     "# SECRET = represents the client secret from an Application Registration\n",
     "RKVST_URL = getenv(\"RKVST_URL\")\n",
-    "APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
-    "APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")\n",
+    "RKVST_APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "RKVST_APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")\n",
     "RKVST_UNIQUE_ID = getenv(\"RKVST_UNIQUE_ID\")\n",
     "if not RKVST_UNIQUE_ID:\n",
     "    raise Exception(\"No value for RKVST_UNIQUE_ID\")"
@@ -68,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c41d7065",
    "metadata": {},
    "outputs": [
@@ -77,7 +90,7 @@
      "output_type": "stream",
      "text": [
       "Connecting to RKVST\n",
-      "URL https://app.dev-paul-0.wild.jitsuin.io\n"
+      "RKVST_URL https://app.rkvst.io\n"
      ]
     }
    ],
@@ -97,13 +110,13 @@
     "\n",
     "# Initialize connection to RKVST\n",
     "print(\"Connecting to RKVST\")\n",
-    "print(\"URL\", RKVST_URL)\n",
-    "arch = Archivist(RKVST_URL, (APPREG_CLIENT, APPREG_SECRET), max_time=300)"
+    "print(\"RKVST_URL\", RKVST_URL)\n",
+    "arch = Archivist(RKVST_URL, (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET), max_time=300)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "b3bff987",
    "metadata": {},
    "outputs": [],
@@ -127,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "5a8456d6",
    "metadata": {},
    "outputs": [],
@@ -149,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "e9129061",
    "metadata": {},
    "outputs": [
@@ -172,16 +185,16 @@
      "output_type": "stream",
      "text": [
       "Asset {\n",
-      "    \"identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6\",\n",
+      "    \"identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802\",\n",
       "    \"behaviours\": [\n",
-      "        \"Attachments\",\n",
       "        \"RecordEvidence\",\n",
       "        \"Builtin\",\n",
-      "        \"AssetCreator\"\n",
+      "        \"AssetCreator\",\n",
+      "        \"Attachments\"\n",
       "    ],\n",
       "    \"attributes\": {\n",
       "        \"arc_display_type\": \"Artists\",\n",
-      "        \"artistid\": \"3242643639\",\n",
+      "        \"artistid\": \"666769323\",\n",
       "        \"genre\": \"Soul\",\n",
       "        \"stage_name\": \"Adele\",\n",
       "        \"arc_description\": \"British Soul Singer\",\n",
@@ -189,13 +202,13 @@
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"tracked\": \"TRACKED\",\n",
-      "    \"owner\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"at_time\": \"2023-01-10T16:25:50Z\",\n",
+      "    \"owner\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"at_time\": \"2023-01-16T11:50:50Z\",\n",
       "    \"storage_integrity\": \"TENANT_STORAGE\",\n",
       "    \"proof_mechanism\": \"SIMPLE_HASH\",\n",
-      "    \"chain_id\": \"99\",\n",
+      "    \"chain_id\": \"827586838445807967\",\n",
       "    \"public\": false,\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n"
      ]
     }
@@ -216,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "4095a75f",
    "metadata": {},
    "outputs": [
@@ -226,8 +239,8 @@
      "text": [
       "Creating Events\n",
       "Event for Album 19 {\n",
-      "    \"identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6/events/75e9fb9a-4e4a-4115-8622-d0863e8480d9\",\n",
-      "    \"asset_identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6\",\n",
+      "    \"identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802/events/dff5e8e1-0933-4dbb-a122-a6a422b5a27e\",\n",
+      "    \"asset_identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802\",\n",
       "    \"event_attributes\": {\n",
       "        \"relase_year\": \"2008\",\n",
       "        \"album_name\": \"19\",\n",
@@ -237,61 +250,61 @@
       "    \"asset_attributes\": {},\n",
       "    \"operation\": \"Record\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
-      "    \"timestamp_declared\": \"2023-01-10T16:25:55Z\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:25:55Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:25:55.427606724Z\",\n",
+      "    \"timestamp_declared\": \"2023-01-16T11:50:56Z\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:50:56Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:50:56.619910777Z\",\n",
       "    \"principal_declared\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"principal_accepted\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"block_number\": 0,\n",
       "    \"transaction_index\": 0,\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n",
       "Event for Album 21 {\n",
-      "    \"identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6/events/b2d6f91c-a467-41a7-9e4f-a8e3a20f6364\",\n",
-      "    \"asset_identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6\",\n",
+      "    \"identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802/events/f74099ab-aab4-48aa-9654-0a09ad324d9b\",\n",
+      "    \"asset_identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802\",\n",
       "    \"event_attributes\": {\n",
-      "        \"album_name\": \"21\",\n",
       "        \"arc_description\": \"Artist Information\",\n",
       "        \"arc_display_type\": \"Album Release\",\n",
-      "        \"relase_year\": \"2011\"\n",
+      "        \"relase_year\": \"2011\",\n",
+      "        \"album_name\": \"21\"\n",
       "    },\n",
       "    \"asset_attributes\": {},\n",
       "    \"operation\": \"Record\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
-      "    \"timestamp_declared\": \"2023-01-10T16:25:55Z\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:25:55Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:25:55.890916542Z\",\n",
+      "    \"timestamp_declared\": \"2023-01-16T11:50:57Z\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:50:57Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:50:57.963815260Z\",\n",
       "    \"principal_declared\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"principal_accepted\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"block_number\": 0,\n",
       "    \"transaction_index\": 0,\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n"
      ]
     }
@@ -304,6 +317,14 @@
     "event_two = create_release(arch, asset, album_name=\"21\", release=\"2011\")\n",
     "print(\"Event for Album 21\", json_dumps(event_two, indent=4))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "fe9cdd06",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -322,7 +343,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.15"
   },
   "vscode": {
    "interpreter": {

--- a/archivist/notebooks/Create Event with Verified Domain.ipynb
+++ b/archivist/notebooks/Create Event with Verified Domain.ipynb
@@ -42,6 +42,8 @@
     "from os import getenv\n",
     "from warnings import filterwarnings\n",
     "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
     "from archivist.archivist import Archivist\n",
     "from archivist.logger import set_logger\n",
     "\n",
@@ -51,6 +53,17 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "7158f0a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext dotenv\n",
+    "%dotenv -o notebooks.env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "a877ffed",
    "metadata": {},
    "outputs": [],
@@ -61,13 +74,13 @@
     "# CLIENT = represents the client ID from an Application Registration\n",
     "# SECRET = represents the client secret from an Application Registration\n",
     "RKVST_URL = getenv(\"RKVST_URL\")\n",
-    "APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
-    "APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")"
+    "RKVST_APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "RKVST_APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "c5f7d4e5",
    "metadata": {},
    "outputs": [
@@ -76,7 +89,7 @@
      "output_type": "stream",
      "text": [
       "Connecting to RKVST\n",
-      "URL https://app.dev-paul-0.wild.jitsuin.io\n"
+      "RKVST_URL https://app.rkvst.io\n"
      ]
     }
    ],
@@ -96,13 +109,13 @@
     "\n",
     "# Initialize connection to RKVST\n",
     "print(\"Connecting to RKVST\")\n",
-    "print(\"URL\", RKVST_URL)\n",
-    "arch = Archivist(RKVST_URL, (APPREG_CLIENT, APPREG_SECRET), max_time=300)"
+    "print(\"RKVST_URL\", RKVST_URL)\n",
+    "arch = Archivist(RKVST_URL, (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET), max_time=300)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "acdf240c",
    "metadata": {},
    "outputs": [],
@@ -126,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "8889c68d",
    "metadata": {},
    "outputs": [],
@@ -183,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "ba24d143",
    "metadata": {},
    "outputs": [],
@@ -201,7 +214,7 @@
     "    attrs = {\n",
     "        \"arc_display_name\": \"display_name\",  # Asset's display name in the user interface\n",
     "        \"arc_description\": \"display_description\",  # Asset's description in the user interface\n",
-    "        \"arc_display_type\": \"desplay_type\",  # Arc_display_type is a free text field\n",
+    "        \"arc_display_type\": \"display_type\",  # Arc_display_type is a free text field\n",
     "        # allowing the creator of\n",
     "        # an asset to specify the asset\n",
     "        # type or class. Be careful when setting this:\n",
@@ -227,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "b7482420",
    "metadata": {
     "scrolled": true
@@ -245,27 +258,27 @@
      "output_type": "stream",
      "text": [
       "Asset {\n",
-      "    \"at_time\": \"2023-01-10T16:22:02Z\",\n",
+      "    \"at_time\": \"2023-01-16T11:53:18Z\",\n",
       "    \"attributes\": {\n",
       "        \"arc_description\": \"display_description\",\n",
       "        \"arc_display_name\": \"display_name\",\n",
-      "        \"arc_display_type\": \"desplay_type\",\n",
+      "        \"arc_display_type\": \"display_type\",\n",
       "        \"some_custom_attribute\": \"value\"\n",
       "    },\n",
       "    \"behaviours\": [\n",
-      "        \"Attachments\",\n",
-      "        \"RecordEvidence\",\n",
       "        \"Builtin\",\n",
-      "        \"AssetCreator\"\n",
+      "        \"AssetCreator\",\n",
+      "        \"Attachments\",\n",
+      "        \"RecordEvidence\"\n",
       "    ],\n",
-      "    \"chain_id\": \"99\",\n",
+      "    \"chain_id\": \"827586838445807967\",\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
-      "    \"identity\": \"assets/bee28a3d-88e8-4906-8c73-2aaa48243572\",\n",
-      "    \"owner\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
+      "    \"identity\": \"assets/0047715f-368e-4a62-aa04-48e6fa974e85\",\n",
+      "    \"owner\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
       "    \"proof_mechanism\": \"SIMPLE_HASH\",\n",
       "    \"public\": false,\n",
       "    \"storage_integrity\": \"TENANT_STORAGE\",\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\",\n",
       "    \"tracked\": \"TRACKED\"\n",
       "}\n",
       "Verified domain '  '\n"
@@ -281,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "bb5b0651",
    "metadata": {},
    "outputs": [
@@ -291,7 +304,7 @@
      "text": [
       "Event {\n",
       "    \"asset_attributes\": {},\n",
-      "    \"asset_identity\": \"assets/bee28a3d-88e8-4906-8c73-2aaa48243572\",\n",
+      "    \"asset_identity\": \"assets/0047715f-368e-4a62-aa04-48e6fa974e85\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
       "    \"block_number\": 0,\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
@@ -300,14 +313,14 @@
       "        \"arc_evidence\": \"DVA Conformance Report attached\",\n",
       "        \"conformance_report\": \"blobs/e2a1d16c-03cd-45a1-8cd0-690831df1273\"\n",
       "    },\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"identity\": \"assets/bee28a3d-88e8-4906-8c73-2aaa48243572/events/2a7aaf85-e927-4170-bbe2-60995696c333\",\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"identity\": \"assets/0047715f-368e-4a62-aa04-48e6fa974e85/events/f94ae41a-fe0d-4c2c-9486-46eeb2579a1f\",\n",
       "    \"operation\": \"Record\",\n",
       "    \"principal_accepted\": {\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\",\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\"\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\"\n",
       "    },\n",
       "    \"principal_declared\": {\n",
       "        \"display_name\": \"\",\n",
@@ -315,9 +328,9 @@
       "        \"issuer\": \"idp.synsation.io/1234\",\n",
       "        \"subject\": \"phil.b\"\n",
       "    },\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:22:06Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:22:06.805648823Z\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:53:21Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:53:21.760625716Z\",\n",
       "    \"timestamp_declared\": \"2019-11-27T14:44:19Z\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"transaction_index\": 0\n",
@@ -335,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "f8ac6dda",
    "metadata": {},
    "outputs": [
@@ -345,7 +358,7 @@
      "text": [
       "Event {\n",
       "    \"asset_attributes\": {},\n",
-      "    \"asset_identity\": \"assets/bee28a3d-88e8-4906-8c73-2aaa48243572\",\n",
+      "    \"asset_identity\": \"assets/0047715f-368e-4a62-aa04-48e6fa974e85\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
       "    \"block_number\": 0,\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
@@ -354,14 +367,14 @@
       "        \"arc_evidence\": \"DVA Conformance Report attached\",\n",
       "        \"conformance_report\": \"blobs/e2a1d16c-03cd-45a1-8cd0-690831df1273\"\n",
       "    },\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"identity\": \"assets/bee28a3d-88e8-4906-8c73-2aaa48243572/events/2a7aaf85-e927-4170-bbe2-60995696c333\",\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"identity\": \"assets/0047715f-368e-4a62-aa04-48e6fa974e85/events/f94ae41a-fe0d-4c2c-9486-46eeb2579a1f\",\n",
       "    \"operation\": \"Record\",\n",
       "    \"principal_accepted\": {\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\",\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\"\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\"\n",
       "    },\n",
       "    \"principal_declared\": {\n",
       "        \"display_name\": \"\",\n",
@@ -369,9 +382,9 @@
       "        \"issuer\": \"idp.synsation.io/1234\",\n",
       "        \"subject\": \"phil.b\"\n",
       "    },\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:22:06Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:22:06.805648823Z\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:53:21Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:53:21.760625716Z\",\n",
       "    \"timestamp_declared\": \"2019-11-27T14:44:19Z\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"transaction_index\": 0\n",
@@ -386,6 +399,14 @@
     "print(\"Event\", json_dumps(event, sort_keys=True, indent=4))\n",
     "print(\"Verified domain '\", get_verified_domain(arch, event), \"'\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "2bde1472",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -404,7 +425,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/archivist/notebooks/Find Asset and Create Attachment.ipynb
+++ b/archivist/notebooks/Find Asset and Create Attachment.ipynb
@@ -40,6 +40,8 @@
     "from os import getenv\n",
     "from warnings import filterwarnings\n",
     "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
     "from archivist.archivist import Archivist\n",
     "from archivist.proof_mechanism import ProofMechanism\n",
     "from archivist.logger import set_logger"
@@ -48,6 +50,17 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "010eed82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext dotenv\n",
+    "%dotenv -o notebooks.env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "da890fb1",
    "metadata": {},
    "outputs": [],
@@ -58,8 +71,8 @@
     "# CLIENT = represents the client ID from an Application Registration\n",
     "# SECRET = represents the client secret from an Application Registration\n",
     "RKVST_URL = getenv(\"RKVST_URL\")\n",
-    "APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
-    "APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")\n",
+    "RKVST_APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "RKVST_APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")\n",
     "RKVST_UNIQUE_ID = getenv(\"RKVST_UNIQUE_ID\")\n",
     "if not RKVST_UNIQUE_ID:\n",
     "    raise Exception(\"RKVST_UNIQUE_ID is undefined\")\n",
@@ -70,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "f9e54f3e",
    "metadata": {},
    "outputs": [
@@ -79,7 +92,7 @@
      "output_type": "stream",
      "text": [
       "Connecting to RKVST\n",
-      "URL https://app.dev-paul-0.wild.jitsuin.io\n"
+      "RKVST_URL https://app.rkvst.io\n"
      ]
     }
    ],
@@ -99,13 +112,13 @@
     "\n",
     "# Initialize connection to RKVST\n",
     "print(\"Connecting to RKVST\")\n",
-    "print(\"URL\", RKVST_URL)\n",
-    "arch = Archivist(RKVST_URL, (APPREG_CLIENT, APPREG_SECRET), max_time=300)"
+    "print(\"RKVST_URL\", RKVST_URL)\n",
+    "arch = Archivist(RKVST_URL, (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET), max_time=300)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "671c824f",
    "metadata": {},
    "outputs": [],
@@ -128,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "3e2d7571",
    "metadata": {},
    "outputs": [],
@@ -148,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "a33b9635",
    "metadata": {},
    "outputs": [],
@@ -177,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "acb00047",
    "metadata": {},
    "outputs": [
@@ -200,30 +213,30 @@
      "output_type": "stream",
      "text": [
       "Asset {\n",
-      "    \"identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6\",\n",
+      "    \"identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802\",\n",
       "    \"behaviours\": [\n",
+      "        \"Builtin\",\n",
       "        \"AssetCreator\",\n",
       "        \"Attachments\",\n",
-      "        \"RecordEvidence\",\n",
-      "        \"Builtin\"\n",
+      "        \"RecordEvidence\"\n",
       "    ],\n",
       "    \"attributes\": {\n",
-      "        \"genre\": \"Soul\",\n",
-      "        \"stage_name\": \"Adele\",\n",
-      "        \"arc_description\": \"British Soul Singer\",\n",
       "        \"arc_display_name\": \"Adele Laurie Blue Adkins\",\n",
       "        \"arc_display_type\": \"Artists\",\n",
-      "        \"artistid\": \"3242643639\"\n",
+      "        \"artistid\": \"666769323\",\n",
+      "        \"genre\": \"Soul\",\n",
+      "        \"stage_name\": \"Adele\",\n",
+      "        \"arc_description\": \"British Soul Singer\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"tracked\": \"TRACKED\",\n",
-      "    \"owner\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"at_time\": \"2023-01-10T16:26:42Z\",\n",
+      "    \"owner\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"at_time\": \"2023-01-16T11:53:49Z\",\n",
       "    \"storage_integrity\": \"TENANT_STORAGE\",\n",
       "    \"proof_mechanism\": \"SIMPLE_HASH\",\n",
-      "    \"chain_id\": \"99\",\n",
+      "    \"chain_id\": \"827586838445807967\",\n",
       "    \"public\": false,\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n"
      ]
     }
@@ -238,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "948c277b",
    "metadata": {},
    "outputs": [
@@ -248,36 +261,36 @@
      "text": [
       "Creating Events for existing Asset\n",
       "Event for Image {\n",
-      "    \"identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6/events/dfbfea31-e97d-4f88-abc8-169eeaa659a8\",\n",
-      "    \"asset_identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6\",\n",
+      "    \"identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802/events/bfeed91b-cf10-4b88-9b46-9ad4f6994551\",\n",
+      "    \"asset_identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802\",\n",
       "    \"event_attributes\": {\n",
-      "        \"arc_display_type\": \"Primary image\",\n",
-      "        \"arc_description\": \"Attaching an image\"\n",
+      "        \"arc_description\": \"Attaching an image\",\n",
+      "        \"arc_display_type\": \"Primary image\"\n",
       "    },\n",
       "    \"asset_attributes\": {},\n",
       "    \"operation\": \"Record\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
-      "    \"timestamp_declared\": \"2023-01-10T16:26:48Z\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:26:48Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:26:48.094799420Z\",\n",
+      "    \"timestamp_declared\": \"2023-01-16T11:53:56Z\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:53:56Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:53:56.424622960Z\",\n",
       "    \"principal_declared\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"principal_accepted\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"block_number\": 0,\n",
       "    \"transaction_index\": 0,\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n"
      ]
     }
@@ -288,6 +301,14 @@
     "image_event = create_image(arch, asset)\n",
     "print(\"Event for Image\", json_dumps(image_event, indent=4))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1edf077",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -306,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.15"
   },
   "vscode": {
    "interpreter": {

--- a/archivist/notebooks/Find Asset and Event Creation.ipynb
+++ b/archivist/notebooks/Find Asset and Event Creation.ipynb
@@ -38,6 +38,8 @@
     "from os import getenv\n",
     "from warnings import filterwarnings\n",
     "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
     "from archivist.archivist import Archivist\n",
     "from archivist.proof_mechanism import ProofMechanism\n",
     "from archivist.logger import set_logger"
@@ -46,6 +48,17 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "9ce08e42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext dotenv\n",
+    "%dotenv -o notebooks.env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "a76365aa",
    "metadata": {},
    "outputs": [],
@@ -56,8 +69,8 @@
     "# CLIENT = represents the client ID from an Application Registration\n",
     "# SECRET = represents the client secret from an Application Registration\n",
     "RKVST_URL = getenv(\"RKVST_URL\")\n",
-    "APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
-    "APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")\n",
+    "RKVST_APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "RKVST_APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")\n",
     "RKVST_UNIQUE_ID = getenv(\"RKVST_UNIQUE_ID\")\n",
     "if not RKVST_UNIQUE_ID:\n",
     "    raise Exception(\"RKVST_UNIQUE_ID is undefined\")"
@@ -65,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "a834f2cd",
    "metadata": {},
    "outputs": [
@@ -74,7 +87,7 @@
      "output_type": "stream",
      "text": [
       "Connecting to RKVST\n",
-      "URL https://app.dev-paul-0.wild.jitsuin.io\n"
+      "RKVST_URL https://app.rkvst.io\n"
      ]
     }
    ],
@@ -94,13 +107,13 @@
     "\n",
     "# Initialize connection to RKVST\n",
     "print(\"Connecting to RKVST\")\n",
-    "print(\"URL\", RKVST_URL)\n",
-    "arch = Archivist(RKVST_URL, (APPREG_CLIENT, APPREG_SECRET), max_time=300)"
+    "print(\"RKVST_URL\", RKVST_URL)\n",
+    "arch = Archivist(RKVST_URL, (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET), max_time=300)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "aa63d95a",
    "metadata": {},
    "outputs": [],
@@ -120,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "66df6ebc",
    "metadata": {},
    "outputs": [],
@@ -142,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "0055fe00",
    "metadata": {},
    "outputs": [
@@ -165,7 +178,7 @@
      "output_type": "stream",
      "text": [
       "Asset {\n",
-      "    \"identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6\",\n",
+      "    \"identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802\",\n",
       "    \"behaviours\": [\n",
       "        \"RecordEvidence\",\n",
       "        \"Builtin\",\n",
@@ -173,30 +186,30 @@
       "        \"Attachments\"\n",
       "    ],\n",
       "    \"attributes\": {\n",
-      "        \"arc_attachments\": [\n",
-      "            {\n",
-      "                \"arc_hash_value\": \"cf0dd630dcfb6e2eac65c362bf7d5ff382a4241ebf45a69a2541ee43320d4af6\",\n",
-      "                \"arc_attachment_identity\": \"blobs/26908610-4ee0-4812-97ec-c0327feecdb5\",\n",
-      "                \"arc_display_name\": \"arc_primary_image\",\n",
-      "                \"arc_hash_alg\": \"SHA256\"\n",
-      "            }\n",
-      "        ],\n",
       "        \"arc_description\": \"British Soul Singer\",\n",
       "        \"arc_display_name\": \"Adele Laurie Blue Adkins\",\n",
       "        \"arc_display_type\": \"Artists\",\n",
-      "        \"artistid\": \"3242643639\",\n",
+      "        \"artistid\": \"666769323\",\n",
       "        \"genre\": \"Soul\",\n",
-      "        \"stage_name\": \"Adele\"\n",
+      "        \"stage_name\": \"Adele\",\n",
+      "        \"arc_attachments\": [\n",
+      "            {\n",
+      "                \"arc_hash_alg\": \"SHA256\",\n",
+      "                \"arc_hash_value\": \"cf0dd630dcfb6e2eac65c362bf7d5ff382a4241ebf45a69a2541ee43320d4af6\",\n",
+      "                \"arc_attachment_identity\": \"blobs/9bfee457-b0ef-4fe9-a51f-16f96ddf8a8a\",\n",
+      "                \"arc_display_name\": \"arc_primary_image\"\n",
+      "            }\n",
+      "        ]\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"tracked\": \"TRACKED\",\n",
-      "    \"owner\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"at_time\": \"2023-01-10T16:27:36Z\",\n",
+      "    \"owner\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"at_time\": \"2023-01-16T11:54:18Z\",\n",
       "    \"storage_integrity\": \"TENANT_STORAGE\",\n",
       "    \"proof_mechanism\": \"SIMPLE_HASH\",\n",
-      "    \"chain_id\": \"99\",\n",
+      "    \"chain_id\": \"827586838445807967\",\n",
       "    \"public\": false,\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n"
      ]
     }
@@ -211,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "8ac5add2",
    "metadata": {},
    "outputs": [
@@ -221,8 +234,8 @@
      "text": [
       "Creating Events for existing Asset\n",
       "Event for Album 25 {\n",
-      "    \"identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6/events/1887ad63-cc65-4a4c-aff7-866a5486df1b\",\n",
-      "    \"asset_identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6\",\n",
+      "    \"identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802/events/676e0177-c7a8-488e-adda-89438f2e3380\",\n",
+      "    \"asset_identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802\",\n",
       "    \"event_attributes\": {\n",
       "        \"arc_description\": \"Artist Information for existing Artist\",\n",
       "        \"arc_display_type\": \"Album Release for existing Artist\",\n",
@@ -232,61 +245,61 @@
       "    \"asset_attributes\": {},\n",
       "    \"operation\": \"Record\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
-      "    \"timestamp_declared\": \"2023-01-10T16:27:41Z\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:27:41Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:27:41.484394554Z\",\n",
+      "    \"timestamp_declared\": \"2023-01-16T11:54:23Z\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:54:23Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:54:23.062210882Z\",\n",
       "    \"principal_declared\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"principal_accepted\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"block_number\": 0,\n",
       "    \"transaction_index\": 0,\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n",
       "Event for Album 30 {\n",
-      "    \"identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6/events/7c5fb22b-76ea-4194-bc40-1214da790601\",\n",
-      "    \"asset_identity\": \"assets/95de60d1-040b-4aff-a0f8-f042334d6ca6\",\n",
+      "    \"identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802/events/d20eb860-bd6b-4d29-951c-dbebb17e2839\",\n",
+      "    \"asset_identity\": \"assets/cbd21a61-c126-4c02-b525-add1a74fb802\",\n",
       "    \"event_attributes\": {\n",
-      "        \"arc_description\": \"Artist Information for existing Artist\",\n",
-      "        \"arc_display_type\": \"Album Release for existing Artist\",\n",
       "        \"relase_year\": \"2021\",\n",
-      "        \"album_name\": \"30\"\n",
+      "        \"album_name\": \"30\",\n",
+      "        \"arc_description\": \"Artist Information for existing Artist\",\n",
+      "        \"arc_display_type\": \"Album Release for existing Artist\"\n",
       "    },\n",
       "    \"asset_attributes\": {},\n",
       "    \"operation\": \"Record\",\n",
       "    \"behaviour\": \"RecordEvidence\",\n",
-      "    \"timestamp_declared\": \"2023-01-10T16:27:42Z\",\n",
-      "    \"timestamp_accepted\": \"2023-01-10T16:27:42Z\",\n",
-      "    \"timestamp_committed\": \"2023-01-10T16:27:42.433674534Z\",\n",
+      "    \"timestamp_declared\": \"2023-01-16T11:54:23Z\",\n",
+      "    \"timestamp_accepted\": \"2023-01-16T11:54:23Z\",\n",
+      "    \"timestamp_committed\": \"2023-01-16T11:54:24.009826690Z\",\n",
       "    \"principal_declared\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"principal_accepted\": {\n",
-      "        \"issuer\": \"https://app.dev-paul-0.wild.jitsuin.io/appidpv1\",\n",
-      "        \"subject\": \"bd3f85d2-9b92-4ef0-82c9-2bcb7b5d25c6\",\n",
-      "        \"display_name\": \"Application display name 05f19055-d2fd-4076-bd02-46a924cbe984\",\n",
+      "        \"issuer\": \"https://app.rkvst.io/appidpv1\",\n",
+      "        \"subject\": \"437bd138-dade-4346-aadd-dfdfee51ddf4\",\n",
+      "        \"display_name\": \"Test Notebooks\",\n",
       "        \"email\": \"\"\n",
       "    },\n",
       "    \"confirmation_status\": \"CONFIRMED\",\n",
       "    \"transaction_id\": \"\",\n",
       "    \"block_number\": 0,\n",
       "    \"transaction_index\": 0,\n",
-      "    \"from\": \"0x3E06AcBf002E8F67bDe832b3f3E7d2aDA2BE3DC8\",\n",
-      "    \"tenant_identity\": \"tenant/f9040e8b-2afa-48f1-bb00-f055d55ade01\"\n",
+      "    \"from\": \"0xe889E67FdBa658C6f27ccBDa98D9d1B5500Dbbce\",\n",
+      "    \"tenant_identity\": \"tenant/9bfb80ee-81f6-40dc-b5c7-1c7fb2fb9866\"\n",
       "}\n"
      ]
     }
@@ -299,6 +312,14 @@
     "event_two = create_release(arch, asset, album_name=\"30\", release=\"2021\")\n",
     "print(\"Event for Album 30\", json_dumps(event_two, indent=4))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1f0eb8f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -317,7 +338,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.15"
   },
   "vscode": {
    "interpreter": {

--- a/archivist/notebooks/Initialization and Credentials.ipynb
+++ b/archivist/notebooks/Initialization and Credentials.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "98edb92d-b177-4dec-b047-1c2cfae82752",
+   "metadata": {},
+   "source": [
+    "# Initialization and Credentials\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "956bfa08-d9cf-4e0a-9221-05a8b03da7c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: rkvst-archivist in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (0.18.1)\n",
+      "Requirement already satisfied: requests~=2.28 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (2.28.1)\n",
+      "Requirement already satisfied: pyaml-env~=1.1 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (1.2.1)\n",
+      "Requirement already satisfied: requests-toolbelt~=0.9 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (0.10.1)\n",
+      "Requirement already satisfied: backoff~=1.11 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (1.11.1)\n",
+      "Requirement already satisfied: certifi in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (2022.12.7)\n",
+      "Requirement already satisfied: rfc3339~=6.2 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (6.2)\n",
+      "Requirement already satisfied: xmltodict~=0.13 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (0.13.0)\n",
+      "Requirement already satisfied: iso8601~=1.0 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (1.1.0)\n",
+      "Requirement already satisfied: flatten-dict~=0.4 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (0.4.2)\n",
+      "Requirement already satisfied: Jinja2~=3.0 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from rkvst-archivist) (3.1.2)\n",
+      "Requirement already satisfied: six<2.0,>=1.12 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from flatten-dict~=0.4->rkvst-archivist) (1.16.0)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from Jinja2~=3.0->rkvst-archivist) (2.1.1)\n",
+      "Requirement already satisfied: PyYAML<=7.0,>=5.0 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from pyaml-env~=1.1->rkvst-archivist) (6.0)\n",
+      "Requirement already satisfied: charset-normalizer<3,>=2 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from requests~=2.28->rkvst-archivist) (2.1.1)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from requests~=2.28->rkvst-archivist) (3.4)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (from requests~=2.28->rkvst-archivist) (1.26.13)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "Requirement already satisfied: python-dotenv in /home/paul/.config/jupyterlab-desktop/jlab_server/lib/python3.8/site-packages (0.21.0)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Install the rkvst-python package\n",
+    "%pip install --upgrade rkvst-archivist\n",
+    "%pip install --upgrade python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5bb82001-bcab-497e-85dc-5809621169be",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RKVST_URL=\"https://app.rkvst.io\"\n",
+      "RKVST_APPREG_CLIENT=\"437bd138-dade-4346-aadd-dfdfee51ddf4\"\n",
+      "RKVST_APPREG_SECRET=\"d26a00cafd9c550228ab3dc9c2303f4c0f79fe9fd00d80fdc92ff2844cdc283e\"\n",
+      "RKVST_ARTIST_ATTACHMENT=\"test_files/pexels-andrea-turner-707697.jpeg\"\n",
+      "RKVST_UNIQUE_ID=\"666769323\"\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from random import randint\n",
+    "\n",
+    "unique_id = randint(1, 1_000_000_000)\n",
+    "\n",
+    "with open(\"notebooks.env\", \"w\", encoding=\"utf-8\") as fd:\n",
+    "    fd.write('RKVST_URL=\"https://app.rkvst.io\"\\n')\n",
+    "    fd.write('RKVST_APPREG_CLIENT=\"437bd138-dade-4346-aadd-dfdfee51ddf4\"\\n')\n",
+    "    fd.write(\n",
+    "        'RKVST_APPREG_SECRET=\"d26a00cafd9c550228ab3dc9c2303f4c0f79fe9fd00d80fdc92ff2844cdc283e\"\\n'\n",
+    "    )\n",
+    "    fd.write('RKVST_ARTIST_ATTACHMENT=\"test_files/pexels-andrea-turner-707697.jpeg\"\\n')\n",
+    "    fd.write(f'RKVST_UNIQUE_ID=\"{unique_id}\"\\n')\n",
+    "\n",
+    "with open(\"notebooks.env\", \"r\") as fd:\n",
+    "    print(fd.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59ead5ce-7e06-41fe-aa75-f49f15259571",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/archivist/notebooks/Manage_Credentials.ipynb
+++ b/archivist/notebooks/Manage_Credentials.ipynb
@@ -26,12 +26,25 @@
     "\n",
     "from os import getenv\n",
     "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
     "from archivist.archivist import Archivist"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "bc989557",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext dotenv\n",
+    "%dotenv -o notebooks.env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "05b3c08d",
    "metadata": {},
    "outputs": [
@@ -39,20 +52,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "URL https://app.rkvst.io\n"
+      "RKVST_URL https://app.rkvst.io\n"
      ]
     }
    ],
    "source": [
     "# Retrieve the URL\n",
     "\n",
-    "URL = getenv(\"RKVST_URL\")\n",
-    "print(\"URL\", URL)"
+    "RKVST_URL = getenv(\"RKVST_URL\")\n",
+    "print(\"RKVST_URL\", RKVST_URL)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "e07100c6",
    "metadata": {},
    "outputs": [],
@@ -64,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "0bcf6c82",
    "metadata": {},
    "outputs": [
@@ -72,7 +85,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "auth_token xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n"
+      "auth_token None\n"
      ]
     }
    ],
@@ -85,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "ceefc550",
    "metadata": {},
    "outputs": [
@@ -100,13 +113,13 @@
    "source": [
     "# Using the JWT to create an Archivist instance\n",
     "\n",
-    "with Archivist(URL, auth_token) as arch:\n",
+    "with Archivist(RKVST_URL, auth_token) as arch:\n",
     "    print(arch)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "097756e3",
    "metadata": {},
    "outputs": [
@@ -114,8 +127,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "client_id yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n",
-      "client_secret zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\n"
+      "RKVST_APPREG_CLIENT cccccccccccccccccccccccccccccccccccc\n",
+      "RKVST_APPREG_SECRET ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss\n"
      ]
     }
    ],
@@ -126,16 +139,16 @@
     "# AppRegistrations POST /archivist/iam/v1/application. Click on 'Try It Out', fill in the request body with a\n",
     "# required display name. Custom claims can be deleted from the example in most cases.\n",
     "\n",
-    "client_id = getenv(\"RKVST_APPREG_CLIENT\")\n",
-    "print(\"client_id\", client_id)\n",
+    "RKVST_APPREG_CLIENT = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "print(\"RKVST_APPREG_CLIENT\", RKVST_APPREG_CLIENT)\n",
     "\n",
-    "client_secret = getenv(\"RKVST_APPREG_SECRET\")\n",
-    "print(\"client_secret\", client_secret)"
+    "RKVST_APPREG_SECRET = getenv(\"RKVST_APPREG_SECRET\")\n",
+    "print(\"RKVST_APPREG_SECRET\", RKVST_APPREG_SECRET)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "f328d435",
    "metadata": {},
    "outputs": [
@@ -150,13 +163,13 @@
    "source": [
     "# Using the application id and secret to create an Archivist instance\n",
     "\n",
-    "with Archivist(URL, (client_id, client_secret)) as arch:\n",
+    "with Archivist(RKVST_URL, (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET)) as arch:\n",
     "    print(arch)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "cfb47ff4",
    "metadata": {},
    "outputs": [
@@ -177,9 +190,17 @@
     "    client_id=getenv(\"RKVST_APPREG_CLIENT\"),\n",
     "    client_secret=getenv(\"RKVST_APPREG_SECRET\"),\n",
     ")\n",
-    "with Archivist(URL, auth) as arch:\n",
+    "with Archivist(RKVST_URL, auth) as arch:\n",
     "    print(arch)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0429ac88-6bb5-495b-bac0-8fe6ab4c3133",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -198,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/archivist/notebooks/Share_Asset.ipynb
+++ b/archivist/notebooks/Share_Asset.ipynb
@@ -26,10 +26,23 @@
     "from json import dumps as json_dumps\n",
     "from os import getenv\n",
     "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
     "from archivist.archivist import Archivist\n",
     "from archivist.constants import ASSET_BEHAVIOURS, SUBJECTS_SELF_ID\n",
     "from archivist.logger import set_logger\n",
     "from archivist.proof_mechanism import ProofMechanism"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf422835",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext dotenv\n",
+    "%dotenv -o notebooks.env"
    ]
   },
   {
@@ -44,13 +57,17 @@
     "# URL = represents the url to the RKVST application\n",
     "# CLIENT = represents the client ID from an Application Registration\n",
     "# SECRET = represents the client secret from an Application Registration\n",
+    "\n",
     "RKVST_URL = getenv(\"RKVST_URL\")\n",
-    "APPREG_CLIENT = {}\n",
-    "APPREG_SECRET = {}\n",
-    "APPREG_CLIENT[\"acme\"] = getenv(\"ACME_APPREG_CLIENT\")\n",
-    "APPREG_SECRET[\"acme\"] = getenv(\"ACME_APPREG_SECRET\")\n",
-    "APPREG_CLIENT[\"weyland\"] = getenv(\"WEYLAND_APPREG_CLIENT\")\n",
-    "APPREG_SECRET[\"weyland\"] = getenv(\"WEYLAND_APPREG_SECRET\")"
+    "\n",
+    "RKVST_APPREG_CLIENT = {}\n",
+    "RKVST_APPREG_SECRET = {}\n",
+    "RKVST_APPREG_CLIENT[\"acme\"] = getenv(\"RKVST_APPREG_CLIENT\")\n",
+    "RKVST_APPREG_SECRET[\"acme\"] = getenv(\"RKVST_APPREG_SECRET\")\n",
+    "RKVST_APPREG_CLIENT[\"weyland\"] = \"cccccccccccccccccccccccccccccccccccc\"\n",
+    "RKVST_APPREG_SECRET[\n",
+    "    \"weyland\"\n",
+    "] = \"ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss\""
    ]
   },
   {
@@ -92,7 +109,7 @@
     "# Initialize connection to acme\n",
     "print(\"Connecting to ACME\")\n",
     "acme = Archivist(\n",
-    "    RKVST_URL, (APPREG_CLIENT[\"acme\"], APPREG_SECRET[\"acme\"]), max_time=300\n",
+    "    RKVST_URL, (RKVST_APPREG_CLIENT[\"acme\"], RKVST_APPREG_SECRET[\"acme\"]), max_time=300\n",
     ")"
    ]
   },
@@ -114,7 +131,9 @@
     "# Initialize connection to weyland\n",
     "print(\"Connecting to WEYLAND\")\n",
     "acme = Archivist(\n",
-    "    RKVST_URL, (APPREG_CLIENT[\"weyland\"], APPREG_SECRET[\"weyland\"]), max_time=300\n",
+    "    RKVST_URL,\n",
+    "    (RKVST_APPREG_CLIENT[\"weyland\"], RKVST_APPREG_SECRET[\"weyland\"]),\n",
+    "    max_time=300,\n",
     ")"
    ]
   },

--- a/archivist/parser.py
+++ b/archivist/parser.py
@@ -152,7 +152,7 @@ def endpoint(args):
         set_logger("INFO")
 
     arch = None
-    LOGGER.info("Initialising connection to RKVST...")
+    LOGGER.info("Initializing connection to RKVST...")
     fixtures = {}
     if args.proof_mechanism is not None:
         fixtures = {

--- a/archivist/runner.py
+++ b/archivist/runner.py
@@ -202,7 +202,7 @@ class _ActionMap(dict):
         """
         Get valid action in map
         """
-        # if an exception occurs here then the dict initialised above is faulty.
+        # if an exception occurs here then the dict initialized above is faulty.
         return self.ops(action_name).get("action")  # type: ignore
 
     def keywords(self, action_name: str) -> Tuple | None:

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -10,63 +10,29 @@ Note Books (BETA)
 These are a collection of jupyter notebooks that demonstrate typical use cases of the RKVST
 system.
 
-They can be downloaded and executed on a Linux, Mac or Windows machines. The only requirement
-is that python3.7 to python3.11 and pip command-line too have been installed.
+They can be downloaded and executed on Linux, Mac or Windows machines.
 
-Installing the RKVST python SDK
-...............................
+The recommended jupyter environment is the JupyterLab Desktop which is available for Linux, Mac or Windows.
 
-The bare requirement is that a version of python3 (3.7 to 3.11) is installed together with
-the pip command-line tool.
+https://github.com/jupyterlab/jupyterlab-desktop
 
-Linux
-~~~~~
-
-Most Linux distros come with a suitable version of python3 already installed. The only extra requirement
-is to install the pip command-line utility. 
-
-.. code:: bash
-
-   python3 -m ensurepip --upgrade
-
-MacOS
-~~~~~
-
-Python installation instructions for MacOS are `pythonmac installation instructions`_
-
-.. _pythonmac installation instructions: https://www.python.org/downloads/macos/
-
-Open a terminal and ensure that python and pip are available:
-
-.. code:: bash
-
-   python --version
-   pip --version
-
-Windows
-~~~~~~~
-
-Python installation instructions for Windows are `pythonwindows installation instructions`_
-
-.. _pythonwindows installation instructions: https://www.python.org/downloads/windows/
-
-Execute the installer. Ensure the following:
-   
-* Installation of pip is enabled
-* py launcher is enabled
-* Associate file with python is enabled
-* Create shortcuts for installed applications
-* Add Python to Path
-
-Open a 'cmd' terminal and ensure that python and pip are available:
-
-.. code:: bash
-
-   python --version
-   pip --version
+    #. Please install this on your desktop following the instructions described in this link.
+        #. When prompted initialize a bundled python environment for JupyterLab Desktop.
+    #. Download the Notebooks from the link below and unzip into a suitable folder.
+    #. Execute JupyterLab Desktop and select the directory where the downloaded notebooks are located.
+    #. Execute the 'Initialization and Credentials' notebook and set your credentials.
+    #. Execute selected notebooks.
+    #. Create new notebooks.....
    
 Download Notebooks
 ..................
+
+Download the notebooks into a suitable folder:
+
+    #. Recommended to call the folder '~/notebooks'
+    #. Restrict access by changing the folder permissions 'chmod 700 ~/notebooks'
+    #. On Windows only allow the owner access to this folder. Either use the dialog or the 'icacls' command.
+
 
 .. only:: builder_html or readthedocs
 
@@ -74,16 +40,36 @@ Download Notebooks
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
-   :name: Gallery
+   :caption: Preparation of Notebooks Environment
+
+   notebooks/Initialization and Credentials.ipynb
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Managing Credentials in Notebook Environment
 
    notebooks/Manage_Credentials
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Basic Asset and Event Examples
+
    notebooks/Create Asset and Events
    notebooks/Find Asset and Event Creation
    notebooks/Find Asset and Create Attachment
+   notebooks/Create Event with Verified Domain
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Compliance Policies Examples
+
    notebooks/Check Asset Compliance using CURRENT OUTSTANDING Policy
    notebooks/Check Asset Compliance using SINCE Policy
-   notebooks/Create Event with Verified Domain
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Asset Sharing
+
    notebooks/Share_Asset
   
    

--- a/docs/notebooks/.gitignore
+++ b/docs/notebooks/.gitignore
@@ -1,3 +1,4 @@
 .ipynb_checkpoints/
+test_files/
 notebooks.zip
 *.ipynb

--- a/docs/notebooks/requirements.txt
+++ b/docs/notebooks/requirements.txt
@@ -5,5 +5,5 @@ jupyter~=1.0
 jupyterlab~=3.5
 jupyter-console~=6.4
 jupyter-contrib-nbextensions~=0.7
-
+python-dotenv[cli]~=0.21.0
 wheel

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -2,6 +2,7 @@ api
 appidp
 args
 boolean
+chmod
 comparator
 config
 cyclonedx
@@ -16,6 +17,7 @@ fda
 formatters
 https
 iam
+icacls
 instantiation
 iterable
 jinja

--- a/functests/execnotebooks.py
+++ b/functests/execnotebooks.py
@@ -49,19 +49,19 @@ class TestNotebooks(TestCase):
             msg="Incorrect URL",
         )
         self.assertEqual(
-            notebook.ref("APPREG_CLIENT"),
+            notebook.ref("RKVST_APPREG_CLIENT"),
             self.client_id,
-            msg="Incorrect APPREG_CLIENT",
+            msg="Incorrect RKVST_APPREG_CLIENT",
         )
         self.assertEqual(
-            notebook.ref("APPREG_SECRET"),
+            notebook.ref("RKVST_APPREG_SECRET"),
             self.client_secret,
-            msg="Incorrect APPREG_SECRET",
+            msg="Incorrect RKVST_APPREG_SECRET",
         )
         self.assertEqual(
-            notebook.cell_output_text(4),
+            notebook.cell_output_text(5),
             f"""Connecting to RKVST
-URL {self.url}""",
+RKVST_URL {self.url}""",
             msg="Incorrect cell output",
         )
 
@@ -91,8 +91,8 @@ URL {self.url}""",
                 0,
                 msg="Incorrect RKVST_UNIQUE_ID",
             )
-            self.check_notebook_cell(notebook, 7)
             self.check_notebook_cell(notebook, 8)
+            self.check_notebook_cell(notebook, 9)
             LOGGER.debug("=================================")
 
     def test_02_find_asset_create_attachment(self):
@@ -115,8 +115,8 @@ URL {self.url}""",
                 0,
                 msg="Incorrect RKVST_ARTIST_ATTACHMENT",
             )
-            self.check_notebook_cell(notebook, 8)
             self.check_notebook_cell(notebook, 9)
+            self.check_notebook_cell(notebook, 10)
             LOGGER.debug("=================================")
 
     def test_03_find_asset_create_event(self):
@@ -134,8 +134,8 @@ URL {self.url}""",
                 0,
                 msg="Incorrect RKVST_UNIQUE_ID",
             )
-            self.check_notebook_cell(notebook, 7)
             self.check_notebook_cell(notebook, 8)
+            self.check_notebook_cell(notebook, 9)
             LOGGER.debug("=================================")
 
     def test_create_event_with_verified_domain(self):
@@ -148,9 +148,9 @@ URL {self.url}""",
         ) as notebook:
             LOGGER.debug("\ncreate_event_with_verified_domain")
             self.basic_notebook_test(notebook)
-            self.check_notebook_cell(notebook, 8)
             self.check_notebook_cell(notebook, 9)
             self.check_notebook_cell(notebook, 10)
+            self.check_notebook_cell(notebook, 11)
             LOGGER.debug("=================================")
 
     def test_check_asset_compliance_current_outstanding(self):
@@ -163,13 +163,13 @@ URL {self.url}""",
         ) as notebook:
             LOGGER.debug("\ncheck_asset_compliance_current_outstanding")
             self.basic_notebook_test(notebook)
-            self.check_notebook_cell(notebook, 9)
             self.check_notebook_cell(notebook, 10)
             self.check_notebook_cell(notebook, 11)
             self.check_notebook_cell(notebook, 12)
             self.check_notebook_cell(notebook, 13)
             self.check_notebook_cell(notebook, 14)
             self.check_notebook_cell(notebook, 15)
+            self.check_notebook_cell(notebook, 16)
             LOGGER.debug("=================================")
 
     def test_check_asset_compliance_since(self):
@@ -182,8 +182,8 @@ URL {self.url}""",
         ) as notebook:
             LOGGER.debug("\ncheck_asset_compliance_since")
             self.basic_notebook_test(notebook)
-            self.check_notebook_cell(notebook, 9)
             self.check_notebook_cell(notebook, 10)
             self.check_notebook_cell(notebook, 11)
             self.check_notebook_cell(notebook, 12)
+            self.check_notebook_cell(notebook, 13)
             LOGGER.debug("=================================")

--- a/scripts/zipnotebooks.sh
+++ b/scripts/zipnotebooks.sh
@@ -15,7 +15,7 @@ then
     echo "${OUTDIR} does not exist"
     exit 1
 fi
-cp "${INDIR}"/*.ipynb "${OUTDIR}"
+cp -r "${INDIR}"/*.ipynb "${INDIR}"/test_files "${OUTDIR}"
 cd "${OUTDIR}"
 rm -f notebooks.zip
-zip notebooks.zip *.ipynb
+zip -r notebooks.zip *.ipynb test_files

--- a/unittests/testnotebooks.py
+++ b/unittests/testnotebooks.py
@@ -89,33 +89,33 @@ class TestNotebooks(TestCase):
             "archivist/notebooks/Manage_Credentials.ipynb", execute=True
         ) as notebook:
             self.assertEqual(
-                notebook.ref("URL"),
-                os.getenv("RKVST_URL"),
+                notebook.ref("RKVST_URL"),
+                f"{URL}",
                 msg="Incorrect URL",
             )
             self.assertEqual(
                 notebook.ref("auth_token"),
-                os.getenv("RKVST_AUTHTOKEN"),
+                f"{AUTHTOKEN}",
                 msg="Incorrect AUTHTOKEN",
             )
             self.assertEqual(
-                notebook.cell_output_text(5),
-                str(Archivist(os.getenv("RKVST_URL"), os.getenv("RKVST_AUTHTOKEN"))),
+                notebook.cell_output_text(6),
+                str(Archivist(f"{URL}", f"{AUTHTOKEN}")),
                 msg="Incorrect Archivist",
             )
             self.assertEqual(
-                notebook.cell_output_text(6),
-                f"""client_id {APPREG_CLIENT}
-client_secret {APPREG_SECRET}""",
+                notebook.cell_output_text(7),
+                f"""RKVST_APPREG_CLIENT {APPREG_CLIENT}
+RKVST_APPREG_SECRET {APPREG_SECRET}""",
                 msg="Incorrect appreg client id and secret",
             )
             self.assertEqual(
-                notebook.cell_output_text(7),
+                notebook.cell_output_text(8),
                 f"Archivist({URL})",
                 msg="Incorrect Archivist",
             )
             self.assertEqual(
-                notebook.cell_output_text(8),
+                notebook.cell_output_text(9),
                 f"Archivist({URL})",
                 msg="Incorrect Archivist",
             )
@@ -126,23 +126,23 @@ client_secret {APPREG_SECRET}""",
         """
         self.assertEqual(
             notebook.ref("RKVST_URL"),
-            os.getenv("RKVST_URL"),
+            f"{URL}",
             msg="Incorrect URL",
         )
         self.assertEqual(
-            notebook.ref("APPREG_CLIENT"),
-            os.getenv("RKVST_APPREG_CLIENT"),
+            notebook.ref("RKVST_APPREG_CLIENT"),
+            f"{APPREG_CLIENT}",
             msg="Incorrect APPREG_CLIENT",
         )
         self.assertEqual(
-            notebook.ref("APPREG_SECRET"),
-            os.getenv("RKVST_APPREG_SECRET"),
+            notebook.ref("RKVST_APPREG_SECRET"),
+            f"{APPREG_SECRET}",
             msg="Incorrect APPREG_SECRET",
         )
         self.assertEqual(
-            notebook.cell_output_text(4),
+            notebook.cell_output_text(5),
             f"""Connecting to RKVST
-URL {URL}""",
+RKVST_URL {URL}""",
             msg="Incorrect cell output",
         )
 
@@ -151,15 +151,15 @@ URL {URL}""",
         Test create_asset_and_events
         """
         with testbook(
-            "archivist/notebooks/Create Asset and Events.ipynb", execute=range(1, 5)
+            "archivist/notebooks/Create Asset and Events.ipynb", execute=(1, 2, 4, 5)
         ) as notebook:
             self.basic_notebook_test(notebook)
 
-            # this is commenetd out as it does not work. There is no way of patching
+            # this is commented out as it does not work. There is no way of patching
             # an object in a notebook (no notebook.patch.object) as notebook code is
             # represented as strings we could 'eval' the strings but for security
-            # reasons the __Repr__ of the Archivist does not emit the credentials so
-            # this isnot possible.
+            # reasons the __repr__ of the Archivist does not emit the credentials so
+            # this is not possible.
             # so we will implement functional tests to test actual code
             # arch = notebook.ref("arch")
             # create_artist = notebook.ref("create_artist")
@@ -176,7 +176,7 @@ URL {URL}""",
         """
         with testbook(
             "archivist/notebooks/Create Event with Verified Domain.ipynb",
-            execute=range(1, 5),
+            execute=range(1, 6),
         ) as notebook:
             self.basic_notebook_test(notebook)
 
@@ -186,7 +186,7 @@ URL {URL}""",
         """
         with testbook(
             "archivist/notebooks/Check Asset Compliance using CURRENT OUTSTANDING Policy.ipynb",
-            execute=range(1, 5),
+            execute=range(1, 6),
         ) as notebook:
             self.basic_notebook_test(notebook)
 
@@ -196,7 +196,7 @@ URL {URL}""",
         """
         with testbook(
             "archivist/notebooks/Check Asset Compliance using SINCE Policy.ipynb",
-            execute=range(1, 5),
+            execute=range(1, 6),
         ) as notebook:
             self.basic_notebook_test(notebook)
 
@@ -206,7 +206,7 @@ URL {URL}""",
         """
         with testbook(
             "archivist/notebooks/Find Asset and Create Attachment.ipynb",
-            execute=range(1, 5),
+            execute=range(1, 6),
         ) as notebook:
             self.basic_notebook_test(notebook)
 
@@ -216,6 +216,6 @@ URL {URL}""",
         """
         with testbook(
             "archivist/notebooks/Find Asset and Event Creation.ipynb",
-            execute=range(1, 5),
+            execute=range(1, 6),
         ) as notebook:
             self.basic_notebook_test(notebook)


### PR DESCRIPTION
Problem:
Jupyter notebooks must be easily executable by third parties on customer's desktops.

Solution:
Add section to docs detailing how to load JupyterLab desktop on Linux, Mac or Windows. Add extra special notebook that initialises environment to the users credentials and tailor all notebooks to use the python-dotenv package to load the same environment.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>