### PR TITLE
Internal pipeline tests failed.

### DIFF
--- a/scripts/pipeline_functests.sh
+++ b/scripts/pipeline_functests.sh
@@ -5,5 +5,7 @@
 rm -rf functest-results
 mkdir -p functest-results
 export PYTHONWARNINGS="ignore:Unverified HTTPS request"
-python -m xmlrunner discover -v -p exec*.py -s functests -o ./functest-results/
+export RKVST_ARTIST_ATTACHMENT=archivist/notebooks/test_files/pexels-andrea-turner-707697.jpeg
+export RKVST_UNIQUE_ID=${SRANDOM}
+python -m xmlrunner discover -v -p exec*.py -t . -s functests -o ./functest-results/
 exit 0


### PR DESCRIPTION
Problem:
Internal pipeline tests failed with relative import error.

Solution:
Explicitly specify the toplevel directory with -t option.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>