### PR TITLE
pipeline-functests fails

### DIFF
--- a/scripts/pipeline_functests.sh
+++ b/scripts/pipeline_functests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # run functests with xml reporting
 


### PR DESCRIPTION
Solution:
Change pipeline-functest.sh to use bash

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>