### PR TITLE
Builder.sh does not run in pipelines

### DIFF
--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -13,8 +13,13 @@ then
     exit 0
 fi
 
+if [ -t 1 ]
+then
+    USE_TTY="-it"
+fi
+
 docker run \
-    --rm -it \
+    --rm ${USE_TTY} \
     -v $(pwd):/home/builder \
     -u $(id -u):$(id -g) \
     -e FUNCTEST \


### PR DESCRIPTION
Problem:
'the input device is not a TTY' error when run in pipeline.

Solution:
Only use -it argument if fd 1 is a tty.