### PR TITLE
Improve linting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,6 +39,7 @@
 
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
+				"charliermarsh.ruff",
 				"ms-python.python",
 				"ms-python.vscode-pylance"
 			]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,8 @@ jobs:
     - name: Install dependencies
       run: |
         export DEBIAN_FRONTEND=noninteractive
+        # https://github.com/community/community/discussions/47863
+        sudo apt-mark hold grub-efi-amd64-signed
         sudo apt-get update
         sudo apt-get upgrade -y --no-install-recommends
         sudo apt-get install -y --fix-missing \

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,6 +21,8 @@ jobs:
     - name: Install dependencies
       run: |
         export DEBIAN_FRONTEND=noninteractive
+        # https://github.com/community/community/discussions/47863
+        sudo apt-mark hold grub-efi-amd64-signed
         sudo apt-get update
         sudo apt-get upgrade -y --no-install-recommends
         sudo apt-get install -y --fix-missing \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,9 +44,22 @@ tasks:
     deps: [about]
     cmds:
       - ./scripts/builder.sh python3 --version
+      - ./scripts/builder.sh ruff check archivist examples functests unittests
       - ./scripts/builder.sh python3 -m pyright archivist
       - ./scripts/builder.sh pycodestyle --format=pylint archivist examples functests unittests
       - ./scripts/builder.sh python3 -m pylint archivist examples functests unittests
+
+  check-fixes:
+    desc: Show proposed fixes from ruff
+    deps: [about]
+    cmds:
+      - ./scripts/builder.sh ruff check --show-fixes archivist examples functests unittests
+
+  check-fixes-apply:
+    desc: Apply  proposed fixes from ruff
+    deps: [about]
+    cmds:
+      - ./scripts/builder.sh ruff check --fix archivist examples functests unittests
 
   clean:
     desc: Clean git repo

--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -22,21 +22,23 @@
 """
 
 from __future__ import annotations
-from logging import getLogger
+
 from copy import deepcopy
-from typing import Any, Generator, Optional
+from logging import getLogger
+from typing import TYPE_CHECKING, Any, Generator, Optional
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
+
+if TYPE_CHECKING:
+    from . import archivist
 
 from .assets import Asset
 from .constants import (
-    ACCESS_POLICIES_SUBPATH,
     ACCESS_POLICIES_LABEL,
+    ACCESS_POLICIES_SUBPATH,
     ASSETS_LABEL,
 )
 from .dictmerge import _deepmerge
-
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/appidp.py
+++ b/archivist/appidp.py
@@ -22,15 +22,20 @@
 """
 
 from __future__ import annotations
+
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 # pylint:disable=too-few-public-methods
-from . import archivist
+
+# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+if TYPE_CHECKING:
+    from . import archivist
 
 from .constants import (
-    APPIDP_SUBPATH,
     APPIDP_LABEL,
+    APPIDP_SUBPATH,
     APPIDP_TOKEN,
 )
 

--- a/archivist/applications.py
+++ b/archivist/applications.py
@@ -22,19 +22,20 @@
 """
 
 from __future__ import annotations
+
 from logging import getLogger
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
+if TYPE_CHECKING:
+    from . import archivist
 
 from .constants import (
-    APPLICATIONS_SUBPATH,
     APPLICATIONS_LABEL,
     APPLICATIONS_REGENERATE,
+    APPLICATIONS_SUBPATH,
 )
 from .dictmerge import _deepmerge
-
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/archivist.py
+++ b/archivist/archivist.py
@@ -30,13 +30,24 @@
 
 """
 from __future__ import annotations
-from logging import getLogger
+
 from copy import deepcopy
+from logging import getLogger
 from time import time
 from typing import Any, BinaryIO, Optional, Tuple
 
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
+from .access_policies import _AccessPoliciesClient
+from .appidp import _AppIDPClient
+from .applications import _ApplicationsClient
+from .archivistpublic import ArchivistPublic
+from .assetattachments import _AssetAttachmentsClient
+from .assets import _AssetsRestricted
+from .attachments import _AttachmentsClient
+from .compliance import _ComplianceClient
+from .compliance_policies import _CompliancePoliciesClient
+from .composite import _CompositeClient
 from .confirmer import MAX_TIME
 from .constants import (
     ROOT,
@@ -44,28 +55,16 @@ from .constants import (
 )
 from .dictmerge import _dotdict
 from .errors import (
-    _parse_response,
     ArchivistError,
+    _parse_response,
 )
-from .archivistpublic import ArchivistPublic
-from .retry429 import retry_429
-
-from .access_policies import _AccessPoliciesClient
-from .appidp import _AppIDPClient
-from .applications import _ApplicationsClient
-from .assets import _AssetsRestricted
-from .assetattachments import _AssetAttachmentsClient
-from .attachments import _AttachmentsClient
-from .compliance import _ComplianceClient
-from .compliance_policies import _CompliancePoliciesClient
-from .composite import _CompositeClient
 from .events import _EventsRestricted
 from .locations import _LocationsClient
+from .retry429 import retry_429
 from .runner import _Runner
 from .sboms import _SBOMSClient
 from .subjects import _SubjectsClient
 from .tenancies import _TenanciesClient
-
 
 LOGGER = getLogger(__name__)
 
@@ -222,10 +221,7 @@ class Archivist(ArchivistPublic):  # pylint: disable=too-many-instance-attribute
         )
 
     def _add_headers(self, headers: dict[str, str] | None) -> dict[str, Any]:
-        if isinstance(headers, dict):
-            newheaders = {**headers}
-        else:
-            newheaders = {}
+        newheaders = {**headers} if isinstance(headers, dict) else {}
 
         auth = self.auth  # this may trigger a refetch so only do it once here
         # for appidp endpoint there may not be an authtoken

--- a/archivist/archivistpublic.py
+++ b/archivist/archivistpublic.py
@@ -23,15 +23,20 @@
 """
 
 from __future__ import annotations
-from logging import getLogger
+
 from collections import deque
 from copy import deepcopy
-from typing import Any, BinaryIO, Optional
+from logging import getLogger
+from typing import TYPE_CHECKING, Any, BinaryIO, Optional
 
 import requests
-from requests.models import Response
+
+if TYPE_CHECKING:
+    from requests.models import Response
 
 
+from .assetattachments import _AssetAttachmentsClient
+from .assets import _AssetsPublic
 from .confirmer import MAX_TIME
 from .constants import (
     HEADERS_REQUEST_TOTAL_COUNT,
@@ -39,18 +44,15 @@ from .constants import (
 )
 from .dictmerge import _deepmerge, _dotdict
 from .errors import (
-    _parse_response,
     ArchivistBadFieldError,
     ArchivistDuplicateError,
     ArchivistHeaderError,
     ArchivistNotFoundError,
+    _parse_response,
 )
+from .events import _EventsPublic
 from .headers import _headers_get
 from .retry429 import retry_429
-
-from .assets import _AssetsPublic
-from .events import _EventsPublic
-from .assetattachments import _AssetAttachmentsClient
 
 LOGGER = getLogger(__name__)
 
@@ -168,10 +170,7 @@ class ArchivistPublic:  # pylint: disable=too-many-instance-attributes
         )
 
     def _add_headers(self, headers: Optional[dict]) -> dict[str, str]:
-        if headers is not None:
-            newheaders = {**headers}
-        else:
-            newheaders = {}
+        newheaders = {**headers} if headers is not None else {}
 
         return newheaders
 

--- a/archivist/asset.py
+++ b/archivist/asset.py
@@ -3,6 +3,8 @@
 """
 from __future__ import annotations
 
+from contextlib import suppress
+
 
 class Asset(dict):
     """Asset
@@ -50,9 +52,7 @@ class Asset(dict):
     def name(self) -> str | None:
         """str: name of the asset"""
         name = None
-        try:
+        with suppress(KeyError, TypeError):
             name = self["attributes"]["arc_display_name"]
-        except (KeyError, TypeError):
-            pass
 
         return name

--- a/archivist/assetattachments.py
+++ b/archivist/assetattachments.py
@@ -25,21 +25,23 @@
 # pylint:disable=too-few-public-methods
 
 from __future__ import annotations
+
 from copy import deepcopy
 from logging import getLogger
-from typing import Any, BinaryIO, Optional
+from typing import TYPE_CHECKING, Any, BinaryIO, Optional
 from urllib.parse import urlparse
 
-from requests.models import Response
+if TYPE_CHECKING:
+    from requests.models import Response
 
-# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
+    # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+    from . import archivist
 
 from .constants import (
-    SEP,
-    ASSETATTACHMENTS_SUBPATH,
     ASSETATTACHMENTS_LABEL,
+    ASSETATTACHMENTS_SUBPATH,
     ATTACHMENTS_LABEL,
+    SEP,
 )
 from .dictmerge import _deepmerge
 

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -22,21 +22,20 @@
 """
 
 from __future__ import annotations
+
+from copy import deepcopy
 from logging import getLogger
 from typing import Any, Optional, Tuple
-from copy import deepcopy
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
-
+from . import archivist, confirmer
 from .asset import Asset
 from .constants import (
     ASSET_BEHAVIOURS,
-    ASSETS_SUBPATH,
     ASSETS_LABEL,
+    ASSETS_SUBPATH,
     CONFIRMATION_STATUS,
 )
-from . import confirmer
 from .dictmerge import _deepmerge
 from .errors import ArchivistBadFieldError, ArchivistNotFoundError
 from .utils import selector_signature

--- a/archivist/attachments.py
+++ b/archivist/attachments.py
@@ -25,20 +25,22 @@
 # pylint:disable=too-few-public-methods
 
 from __future__ import annotations
+
 from copy import deepcopy
 from io import BytesIO
 from logging import getLogger
 from os import path
-from typing import BinaryIO, Optional, Any
+from typing import TYPE_CHECKING, Any, BinaryIO, Optional
 
-from requests.models import Response
+if TYPE_CHECKING:
+    from requests.models import Response
 
-# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
+    # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+    from . import archivist
 
 from .constants import (
-    ATTACHMENTS_SUBPATH,
     ATTACHMENTS_LABEL,
+    ATTACHMENTS_SUBPATH,
 )
 from .dictmerge import _deepmerge
 from .utils import get_url

--- a/archivist/cmds/runner/__main__.py
+++ b/archivist/cmds/runner/__main__.py
@@ -3,7 +3,6 @@
 
 from .main import main
 
-
 if __name__ == "__main__":
     # execute only if run as a script
     main()

--- a/archivist/cmds/runner/main.py
+++ b/archivist/cmds/runner/main.py
@@ -5,7 +5,6 @@ from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
 from ...parser import common_parser, endpoint
-
 from .run import run
 
 LOGGER = getLogger(__name__)

--- a/archivist/cmds/runner/run.py
+++ b/archivist/cmds/runner/run.py
@@ -1,17 +1,15 @@
 # pylint:  disable=missing-docstring
 
 from __future__ import annotations
+
 from logging import getLogger
 from os import environ
 from sys import exit as sys_exit
 
 from pyaml_env import parse_config
 
-from ... import about
-
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from ... import archivist
-
+from ... import about, archivist
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/cmds/template/__main__.py
+++ b/archivist/cmds/template/__main__.py
@@ -3,7 +3,6 @@
 
 from .main import main
 
-
 if __name__ == "__main__":
     # execute only if run as a script
     main()

--- a/archivist/cmds/template/main.py
+++ b/archivist/cmds/template/main.py
@@ -5,7 +5,6 @@ from sys import exit as sys_exit
 from sys import stdout as sys_stdout
 
 from ...parser import common_parser, endpoint
-
 from .run import run
 
 LOGGER = getLogger(__name__)

--- a/archivist/cmds/template/run.py
+++ b/archivist/cmds/template/run.py
@@ -5,14 +5,13 @@ from os import environ
 from pathlib import PurePath
 from sys import exit as sys_exit
 
-from jinja2 import Environment, FileSystemLoader
 import yaml
+from jinja2 import Environment, FileSystemLoader
 
 from ... import about
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 from ... import archivist as type_helper  # pylint:disable=unused-import
-
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/compliance.py
+++ b/archivist/compliance.py
@@ -22,17 +22,18 @@
 """
 
 from __future__ import annotations
-from logging import getLogger
-from typing import Any, Optional
 
-# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
+from logging import getLogger
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+    from . import archivist
 
 from .constants import (
-    COMPLIANCE_SUBPATH,
     COMPLIANCE_LABEL,
+    COMPLIANCE_SUBPATH,
 )
-
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/compliance_policies.py
+++ b/archivist/compliance_policies.py
@@ -26,26 +26,27 @@
 """
 
 from __future__ import annotations
+
 from copy import deepcopy
 from logging import getLogger
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
+if TYPE_CHECKING:
+    # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+    from . import archivist
+    from .compliance_policy_requests import (
+        CompliancePolicyCurrentOutstanding,
+        CompliancePolicyDynamicTolerance,
+        CompliancePolicyPeriodOutstanding,
+        CompliancePolicyRichness,
+        CompliancePolicySince,
+    )
 
-from .compliance_policy_requests import (
-    CompliancePolicySince,
-    CompliancePolicyCurrentOutstanding,
-    CompliancePolicyPeriodOutstanding,
-    CompliancePolicyDynamicTolerance,
-    CompliancePolicyRichness,
-)
 from .constants import (
-    COMPLIANCE_POLICIES_SUBPATH,
     COMPLIANCE_POLICIES_LABEL,
+    COMPLIANCE_POLICIES_SUBPATH,
 )
 from .dictmerge import _deepmerge
-
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/compliance_policy_requests.py
+++ b/archivist/compliance_policy_requests.py
@@ -5,7 +5,8 @@
 """
 
 from __future__ import annotations
-from dataclasses import dataclass, asdict
+
+from dataclasses import asdict, dataclass
 
 from .compliance_policy_type import CompliancePolicyType
 from .or_dict import and_list

--- a/archivist/composite.py
+++ b/archivist/composite.py
@@ -22,10 +22,13 @@
 """
 
 from __future__ import annotations
-from logging import getLogger
 
-# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+    from . import archivist
 
 
 LOGGER = getLogger(__name__)

--- a/archivist/confirmer.py
+++ b/archivist/confirmer.py
@@ -2,12 +2,16 @@
 """
 
 from __future__ import annotations
-from logging import getLogger
 
 from copy import deepcopy
-from typing import Any, Optional, overload, Union
+from logging import getLogger
+from typing import TYPE_CHECKING, Any, Optional, Union, overload
 
 import backoff
+
+if TYPE_CHECKING:
+    # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+    from . import assets, events
 
 from .constants import (
     CONFIRMATION_CONFIRMED,
@@ -16,23 +20,18 @@ from .constants import (
     CONFIRMATION_STATUS,
 )
 from .errors import ArchivistUnconfirmedError
-
-
-# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import assets
-from . import events
 from .utils import backoff_handler
-
 
 MAX_TIME = 1200
 LOGGER = getLogger(__name__)
 
-# pylint: disable=protected-access
-PublicManagers = Union[assets._AssetsPublic, events._EventsPublic]
-PrivateManagers = Union[assets._AssetsRestricted, events._EventsRestricted]
-Managers = Union[PublicManagers, PrivateManagers]
+if TYPE_CHECKING:
+    # pylint: disable=protected-access
+    PublicManagers = Union[assets._AssetsPublic, events._EventsPublic]
+    PrivateManagers = Union[assets._AssetsRestricted, events._EventsRestricted]
+    Managers = Union[PublicManagers, PrivateManagers]
 
-ReturnTypes = Union[assets.Asset, events.Event]
+    ReturnTypes = Union[assets.Asset, events.Event]
 
 
 def __lookup_max_time():

--- a/archivist/dictmerge.py
+++ b/archivist/dictmerge.py
@@ -1,6 +1,7 @@
 """Archivist dict deep merge
 """
 from __future__ import annotations
+
 from copy import deepcopy
 from typing import Any, Optional
 

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -23,13 +23,13 @@
 """
 
 from __future__ import annotations
+
 from copy import deepcopy
 from logging import getLogger
 from typing import Any, Optional
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
-
+from . import archivist, confirmer
 from .constants import (
     ASSETS_SUBPATH,
     ASSETS_WILDCARD,
@@ -37,10 +37,8 @@ from .constants import (
     EVENTS_LABEL,
     SBOM_RELEASE,
 )
-from . import confirmer
 from .dictmerge import _deepmerge
 from .errors import ArchivistBadFieldError, ArchivistNotFoundError
-
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/headers.py
+++ b/archivist/headers.py
@@ -5,6 +5,7 @@
 
 
 from typing import Optional
+
 from requests import models
 
 

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -23,18 +23,20 @@
 """
 
 from __future__ import annotations
+
+from contextlib import suppress
 from copy import deepcopy
 from logging import getLogger
-from typing import Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
+if TYPE_CHECKING:
+    # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+    from . import archivist
 
-from .constants import LOCATIONS_SUBPATH, LOCATIONS_LABEL
+from .constants import LOCATIONS_LABEL, LOCATIONS_SUBPATH
 from .dictmerge import _deepmerge
 from .errors import ArchivistNotFoundError
 from .utils import selector_signature
-
 
 LOGGER = getLogger(__name__)
 
@@ -50,10 +52,8 @@ class Location(dict):
     def name(self) -> str | None:
         """str: name of the location"""
         name = None
-        try:
+        with suppress(KeyError):
             name = self["display_name"]
-        except KeyError:
-            pass
 
         return name
 

--- a/archivist/or_dict.py
+++ b/archivist/or_dict.py
@@ -6,6 +6,7 @@
 """
 
 from __future__ import annotations
+
 from typing import Any
 
 

--- a/archivist/parser.py
+++ b/archivist/parser.py
@@ -17,7 +17,6 @@ from .logger import set_logger
 from .proof_mechanism import ProofMechanism
 from .utils import get_auth
 
-
 filterwarnings("ignore", message="Unverified HTTPS request")
 
 

--- a/archivist/publisher.py
+++ b/archivist/publisher.py
@@ -4,13 +4,17 @@
 """
 
 from __future__ import annotations
+
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 import backoff
 
-from .utils import backoff_handler
 from .errors import ArchivistUnpublishedError
-from . import sboms
+from .utils import backoff_handler
+
+if TYPE_CHECKING:
+    from . import sboms
 
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature

--- a/archivist/runner.py
+++ b/archivist/runner.py
@@ -4,20 +4,23 @@ Base runner class for interpreting yaml story files.
 """
 
 from __future__ import annotations
+
 from collections import defaultdict
 from functools import partialmethod
 from json import dumps as json_dumps
 from logging import getLogger
 from time import sleep as time_sleep
 from types import GeneratorType
-from typing import Any, Callable, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 from uuid import UUID
+
+from .errors import ArchivistError, ArchivistInvalidOperationError
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 # pylint:disable=missing-function-docstring
 # pylint:disable=protected-access
-from . import archivist
-from .errors import ArchivistError, ArchivistInvalidOperationError
+if TYPE_CHECKING:
+    from . import archivist
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/sbommetadata.py
+++ b/archivist/sbommetadata.py
@@ -6,7 +6,8 @@
 # pylint:disable=too-many-instance-attributes
 
 from __future__ import annotations
-from dataclasses import dataclass, asdict
+
+from dataclasses import asdict, dataclass
 from inspect import signature as inspect_signature
 from logging import getLogger
 

--- a/archivist/sboms.py
+++ b/archivist/sboms.py
@@ -25,26 +25,26 @@
 # pylint:disable=too-few-public-methods
 
 from __future__ import annotations
-from typing import BinaryIO, Optional, Any
+
 from copy import deepcopy
 from io import BytesIO
 from logging import getLogger
+from typing import TYPE_CHECKING, Any, BinaryIO, Optional
 
-from requests.models import Response
+if TYPE_CHECKING:
+    from requests.models import Response
 from xmltodict import parse as xmltodict_parse
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
-
+from . import archivist, publisher, uploader, withdrawer
 from .constants import (
-    SBOMS_SUBPATH,
     SBOMS_LABEL,
     SBOMS_METADATA,
+    SBOMS_PUBLISH,
+    SBOMS_SUBPATH,
     SBOMS_WILDCARD,
     SBOMS_WITHDRAW,
-    SBOMS_PUBLISH,
 )
-from . import publisher, uploader, withdrawer
 from .dictmerge import _deepmerge
 from .sbommetadata import SBOM
 from .utils import get_url

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -22,22 +22,20 @@
 """
 
 from __future__ import annotations
+
 from base64 import b64decode
 from json import loads as json_loads
 from logging import getLogger
 from typing import Any, Optional, Tuple
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
-
+from . import archivist, subjects_confirmer
 from .constants import (
     SUBJECTS_LABEL,
     SUBJECTS_SELF_ID,
     SUBJECTS_SUBPATH,
 )
-from . import subjects_confirmer
 from .dictmerge import _deepmerge
-
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/subjects_confirmer.py
+++ b/archivist/subjects_confirmer.py
@@ -2,17 +2,20 @@
 """
 
 from __future__ import annotations
+
 from logging import getLogger
+from typing import TYPE_CHECKING
+
 import backoff
 
-from . import subjects
+if TYPE_CHECKING:
+    from . import subjects
 
 from .constants import (
     CONFIRMATION_CONFIRMED,
     CONFIRMATION_STATUS,
 )
 from .errors import ArchivistUnconfirmedError
-
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 from .utils import backoff_handler

--- a/archivist/tenancies.py
+++ b/archivist/tenancies.py
@@ -22,17 +22,19 @@
 """
 
 from __future__ import annotations
-from logging import getLogger
 
-# pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
+    from . import archivist
 
 from .constants import (
     TENANCIES_LABEL,
     TENANCIES_PREFIX,
     TENANCIES_SUBPATH,
 )
-
 
 LOGGER = getLogger(__name__)
 

--- a/archivist/timestamp.py
+++ b/archivist/timestamp.py
@@ -5,6 +5,7 @@
 """
 
 from datetime import datetime
+
 from iso8601 import parse_date
 from rfc3339 import rfc3339
 

--- a/archivist/uploader.py
+++ b/archivist/uploader.py
@@ -1,12 +1,16 @@
 """uploader interface
 """
 from __future__ import annotations
+
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 import backoff
 
 from .errors import ArchivistNotFoundError
-from . import sboms
+
+if TYPE_CHECKING:
+    from . import sboms
 
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature

--- a/archivist/utils.py
+++ b/archivist/utils.py
@@ -2,9 +2,12 @@
 """
 
 from __future__ import annotations
-from io import BytesIO
+
 from logging import getLogger
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:
+    from io import BytesIO
 
 from requests import get as requests_get
 
@@ -38,7 +41,7 @@ def backoff_handler(details):
 
 
 # download arbitrary files from a url.
-def get_url(url: str, fd: BytesIO):  # pragma no cover
+def get_url(url: str, fd: BytesIO):  # pragma: no cover
     """GET method (REST) - chunked
 
     Downloads a binary object from upstream storage.
@@ -61,7 +64,7 @@ def get_auth(
     client_id=None,
     client_secret_filename=None,
     client_secret=None,
-):  # pragma no cover
+):  # pragma: no cover
     """
     Return auth as either stuntidp token or client_id,client_secret tuple
     """

--- a/archivist/withdrawer.py
+++ b/archivist/withdrawer.py
@@ -4,13 +4,17 @@
 """
 
 from __future__ import annotations
+
 from logging import getLogger
+from typing import TYPE_CHECKING
 
 import backoff
 
-from .utils import backoff_handler
 from .errors import ArchivistUnwithdrawnError
-from . import sboms
+from .utils import backoff_handler
+
+if TYPE_CHECKING:
+    from . import sboms
 
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature

--- a/examples/get_asset.py
+++ b/examples/get_asset.py
@@ -10,7 +10,7 @@ from os import getenv
 from warnings import filterwarnings
 
 from archivist.archivist import Archivist
-from archivist.errors import ArchivistNotFoundError, ArchivistDuplicateError
+from archivist.errors import ArchivistDuplicateError, ArchivistNotFoundError
 
 filterwarnings("ignore", message="Unverified HTTPS request")
 

--- a/functests/execaccess_policies.py
+++ b/functests/execaccess_policies.py
@@ -9,12 +9,11 @@ from time import sleep
 from unittest import skipIf
 from uuid import uuid4
 
+from archivist import logger
 from archivist.archivist import Archivist
 from archivist.constants import ASSET_BEHAVIOURS
 from archivist.proof_mechanism import ProofMechanism
 from archivist.utils import get_auth
-
-from archivist import logger
 
 from .constants import TestCase
 

--- a/functests/execapplications.py
+++ b/functests/execapplications.py
@@ -8,12 +8,11 @@ from time import sleep
 from unittest import skipIf
 from uuid import uuid4
 
+from archivist import logger
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistUnauthenticatedError
 from archivist.proof_mechanism import ProofMechanism
 from archivist.utils import get_auth
-
-from archivist import logger
 
 from .constants import TestCase
 
@@ -200,7 +199,7 @@ class TestApplications(TestCase):
         client_id = application["client_id"]
         client_secret = "X" + application["credentials"][0]["secret"][1:]
         with self.assertRaises(ArchivistUnauthenticatedError):
-            appidp = self.arch.appidp.token(
+            self.arch.appidp.token(
                 client_id,
                 client_secret,
             )

--- a/functests/execassets.py
+++ b/functests/execassets.py
@@ -7,12 +7,11 @@ from json import dumps as json_dumps
 from os import getenv
 from uuid import uuid4
 
+from archivist import logger
 from archivist.archivist import Archivist
 from archivist.constants import ASSET_BEHAVIOURS
 from archivist.proof_mechanism import ProofMechanism
 from archivist.utils import get_auth
-
-from archivist import logger
 
 from .constants import TestCase
 
@@ -161,7 +160,7 @@ class TestAssetCreate(TestCase):
                 },
             },
         }
-        traffic_light = traffic_lights.assets.create(
+        traffic_lights.assets.create(
             attrs=self.attrs,
             confirm=True,
         )
@@ -180,7 +179,7 @@ class TestAssetCreate(TestCase):
                 },
             },
         }
-        fancy_traffic_light = fancy_traffic_lights.assets.create(
+        fancy_traffic_lights.assets.create(
             attrs=self.attrs,
             confirm=True,
         )

--- a/functests/execattachments.py
+++ b/functests/execattachments.py
@@ -3,16 +3,15 @@ Tests the upload and download functionality of the SDK
 """
 from contextlib import suppress
 from filecmp import clear_cache, cmp
-from json import dumps as json_dumps
 from io import BytesIO
+from json import dumps as json_dumps
 from os import getenv, remove
 from unittest import skipIf
 
+from archivist import logger
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistBadRequestError
 from archivist.utils import get_auth, get_url
-
-from archivist import logger
 
 from .constants import TestCase
 
@@ -156,11 +155,12 @@ class TestAttachmentsCreate(TestCase):
             attachment = self.arch.attachments.upload(fd)
             file_uuid = attachment["identity"]
 
-        with open(self.RKVST_IMAGE_DOWNLOAD_PATH, "wb") as fd:
-            with self.assertRaises(ArchivistBadRequestError):
-                attachment = self.arch.attachments.download(
-                    file_uuid, fd, params={"strict": "true"}
-                )
+        with open(self.RKVST_IMAGE_DOWNLOAD_PATH, "wb") as fd, self.assertRaises(
+            ArchivistBadRequestError
+        ):
+            attachment = self.arch.attachments.download(
+                file_uuid, fd, params={"strict": "true"}
+            )
 
 
 class TestAttachmentstMalware(TestCase):

--- a/functests/execcompliance_policies.py
+++ b/functests/execcompliance_policies.py
@@ -6,6 +6,7 @@ from os import getenv
 from time import sleep
 from uuid import uuid4
 
+from archivist import logger
 from archivist.archivist import Archivist
 from archivist.compliance_policy_requests import (
     CompliancePolicyCurrentOutstanding,
@@ -16,8 +17,6 @@ from archivist.compliance_policy_requests import (
 )
 from archivist.compliance_policy_type import CompliancePolicyType
 from archivist.utils import get_auth
-
-from archivist import logger
 
 from .constants import TestCase
 

--- a/functests/execnotebooks.py
+++ b/functests/execnotebooks.py
@@ -5,13 +5,11 @@ from os import getenv
 
 from testbook import testbook
 
-from archivist.archivist import Archivist
-
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
-
 from archivist import logger
+from archivist.archivist import Archivist
 
 from .constants import TestCase
 

--- a/functests/execpublicassets.py
+++ b/functests/execpublicassets.py
@@ -7,13 +7,12 @@ from json import dumps as json_dumps
 from os import getenv
 from time import sleep
 
+from archivist import logger
 from archivist.archivist import Archivist
 from archivist.constants import ASSET_BEHAVIOURS
 from archivist.proof_mechanism import ProofMechanism
 from archivist.timestamp import now_timestamp
 from archivist.utils import get_auth
-
-from archivist import logger
 
 from .constants import TestCase
 
@@ -175,7 +174,7 @@ class TestPublicAssetCreate(TestCase):
             identity,
             msg="Identity is None",
         )
-        asset_publicurl = self.arch.assets.publicurl(asset["identity"])
+        self.arch.assets.publicurl(asset["identity"])
         # different behaviours are also different.
         props = {
             "operation": "Record",

--- a/functests/execrunner.py
+++ b/functests/execrunner.py
@@ -2,16 +2,15 @@
 Test runner
 """
 
-from os import getenv, environ
+from os import environ, getenv
 
+import yaml
 from jinja2 import Environment, FileSystemLoader
 from pyaml_env import parse_config
-import yaml
-
-from archivist.archivist import Archivist
-from archivist.utils import get_auth
 
 from archivist import logger
+from archivist.archivist import Archivist
+from archivist.utils import get_auth
 
 from .constants import TestCase
 

--- a/functests/execsboms.py
+++ b/functests/execsboms.py
@@ -7,12 +7,11 @@ from json import dumps as json_dumps
 from os import getenv, remove
 from time import sleep
 
+from archivist import logger
 from archivist.archivist import Archivist
 from archivist.errors import ArchivistBadRequestError
 from archivist.timestamp import now_timestamp
 from archivist.utils import get_auth
-
-from archivist import logger
 
 from .constants import TestCase
 
@@ -92,11 +91,10 @@ class TestSBOM(TestCase):
         """
         now = now_timestamp()
         LOGGER.debug("Illegal Upload Title: %s %s", self.title, now)
-        with open(RKVST_SBOM_PATH, "rb") as fd:
-            with self.assertRaises(ArchivistBadRequestError):
-                metadata = self.arch.sboms.upload(
-                    fd, confirm=True, params={"privacy": "XXXXXX"}
-                )
+        with open(RKVST_SBOM_PATH, "rb") as fd, self.assertRaises(
+            ArchivistBadRequestError
+        ):
+            self.arch.sboms.upload(fd, confirm=True, params={"privacy": "XXXXXX"})
 
     def test_sbom_upload_with_spdx(self):
         """
@@ -131,11 +129,10 @@ class TestSBOM(TestCase):
         """
         now = now_timestamp()
         LOGGER.debug("SPDX Upload Title: %s %s", self.title, now)
-        with open(RKVST_SBOM_SPDX_PATH, "rb") as fd:
-            with self.assertRaises(ArchivistBadRequestError):
-                metadata = self.arch.sboms.upload(
-                    fd, confirm=True, params={"sbomType": "xxxxxxxx"}
-                )
+        with open(RKVST_SBOM_SPDX_PATH, "rb") as fd, self.assertRaises(
+            ArchivistBadRequestError
+        ):
+            self.arch.sboms.upload(fd, confirm=True, params={"sbomType": "xxxxxxxx"})
 
     def test_sbom_upload_with_confirmation(self):
         """

--- a/functests/execsubjects.py
+++ b/functests/execsubjects.py
@@ -5,14 +5,12 @@ from json import dumps as json_dumps
 from os import getenv
 from uuid import uuid4
 
-from archivist.archivist import Archivist
-from archivist.utils import get_auth
-
 # pylint: disable=fixme
 # pylint: disable=missing-docstring
 # pylint: disable=unused-variable
-
 from archivist import logger
+from archivist.archivist import Archivist
+from archivist.utils import get_auth
 
 from .constants import TestCase
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.coverage.report]
 fail_under = 100
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING",
+]
 
 [tool.coverage.run]
 omit = [
@@ -369,7 +373,18 @@ confidence = ["HIGH", "CONTROL_FLOW", "INFERENCE", "INFERENCE_FAILURE", "UNDEFIN
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable = ["raw-checker-failed", "bad-inline-option", "locally-disabled", "file-ignored", "suppressed-message", "useless-suppression", "deprecated-pragma", "use-symbolic-message-instead"]
+disable = [
+    "bad-inline-option",
+    "deprecated-pragma",
+    "file-ignored",
+    "locally-disabled",
+    "pointless-statement",
+    "raw-checker-failed",
+    "suppressed-message",
+    "use-symbolic-message-instead",
+    "useless-suppression",
+    "wrong-import-position",
+]
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -543,5 +558,19 @@ ignored-argument-names = "_.*|^ignored_|^unused_"
 # List of qualified module names which can have objects that can redefine
 # builtins.
 redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", "builtins", "io"]
+
+# this will eventually be the de facto linter and pylint,pycodestyle etc will be removed.
+# we can add a host of checkers in extend-select but for now lets keep it simple
+[tool.ruff]
+extend-select = [
+    "C4",
+    "E",
+    "I",
+    "SIM",
+    "TCH",
+]
+ignore = ["E501"]
+show-fixes = true
+target-version = "py37"
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,9 @@ black[jupyter]~=23.1
 coverage[toml]~=7.1
 pip-audit~=2.4
 pycodestyle~=2.10
-pylint~=2.16
+pylint~=2.17
 pyright~=1.1
+ruff~=0.0.254
 unittest-xml-reporting~=3.2
 testbook~=0.4
 

--- a/unittests/testaccess_policies.py
+++ b/unittests/testaccess_policies.py
@@ -6,19 +6,18 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.constants import (
+    ACCESS_POLICIES_LABEL,
+    ACCESS_POLICIES_SUBPATH,
     ASSET_BEHAVIOURS,
-    ROOT,
+    ASSETS_LABEL,
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
-    ACCESS_POLICIES_SUBPATH,
-    ACCESS_POLICIES_LABEL,
-    ASSETS_LABEL,
+    ROOT,
 )
 from archivist.errors import ArchivistBadRequestError
 
 from .mock_response import MockResponse
 from .testassets import RESPONSE as ASSET
-
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -150,7 +149,7 @@ class TestAccessPolicies(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200, **RESPONSE)
 
-            access_policy = self.arch.access_policies.read(IDENTITY)
+            self.arch.access_policies.read(IDENTITY)
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -173,7 +172,7 @@ class TestAccessPolicies(TestCase):
         with mock.patch.object(self.arch.session, "delete") as mock_delete:
             mock_delete.return_value = MockResponse(200, {})
 
-            access_policy = self.arch.access_policies.delete(IDENTITY)
+            self.arch.access_policies.delete(IDENTITY)
             self.assertEqual(
                 tuple(mock_delete.call_args),
                 (
@@ -195,7 +194,7 @@ class TestAccessPolicies(TestCase):
         with mock.patch.object(self.arch.session, "patch") as mock_patch:
             mock_patch.return_value = MockResponse(200, **RESPONSE)
 
-            access_policy = self.arch.access_policies.update(
+            self.arch.access_policies.update(
                 IDENTITY,
                 props=PROPS,
             )
@@ -224,7 +223,7 @@ class TestAccessPolicies(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(400)
             with self.assertRaises(ArchivistBadRequestError):
-                resp = self.arch.access_policies.read(IDENTITY)
+                self.arch.access_policies.read(IDENTITY)
 
     def test_access_policies_count(self):
         """
@@ -274,7 +273,7 @@ class TestAccessPolicies(TestCase):
                 ],
             )
 
-            count = self.arch.access_policies.count(
+            self.arch.access_policies.count(
                 display_name="Policy display name",
             )
             self.assertEqual(

--- a/unittests/testappidp.py
+++ b/unittests/testappidp.py
@@ -6,14 +6,13 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.constants import (
-    ROOT,
-    APPIDP_SUBPATH,
     APPIDP_LABEL,
+    APPIDP_SUBPATH,
     APPIDP_TOKEN,
+    ROOT,
 )
 
 from .mock_response import MockResponse
-
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access

--- a/unittests/testapplications.py
+++ b/unittests/testapplications.py
@@ -6,15 +6,14 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.constants import (
-    ROOT,
-    APPLICATIONS_SUBPATH,
     APPLICATIONS_LABEL,
     APPLICATIONS_REGENERATE,
+    APPLICATIONS_SUBPATH,
+    ROOT,
 )
 from archivist.errors import ArchivistBadRequestError
 
 from .mock_response import MockResponse
-
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -113,7 +112,7 @@ class TestApplications(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200, **RESPONSE)
 
-            application = self.arch.applications.read(IDENTITY)
+            self.arch.applications.read(IDENTITY)
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -136,7 +135,7 @@ class TestApplications(TestCase):
         with mock.patch.object(self.arch.session, "delete") as mock_delete:
             mock_delete.return_value = MockResponse(200, {})
 
-            application = self.arch.applications.delete(IDENTITY)
+            self.arch.applications.delete(IDENTITY)
             self.assertEqual(
                 tuple(mock_delete.call_args),
                 (
@@ -158,7 +157,7 @@ class TestApplications(TestCase):
         with mock.patch.object(self.arch.session, "patch") as mock_patch:
             mock_patch.return_value = MockResponse(200, **RESPONSE)
 
-            application = self.arch.applications.update(
+            self.arch.applications.update(
                 IDENTITY,
                 display_name=DISPLAY_NAME,
             )
@@ -184,7 +183,7 @@ class TestApplications(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(400)
             with self.assertRaises(ArchivistBadRequestError):
-                resp = self.arch.applications.read(IDENTITY)
+                self.arch.applications.read(IDENTITY)
 
     def test_applications_list(self):
         """
@@ -281,7 +280,7 @@ class TestApplications(TestCase):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
-            sbom = self.arch.applications.regenerate(IDENTITY)
+            self.arch.applications.regenerate(IDENTITY)
             self.assertEqual(
                 tuple(mock_post.call_args),
                 (

--- a/unittests/testarchivist.py
+++ b/unittests/testarchivist.py
@@ -7,7 +7,7 @@ from os import environ
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
-from archivist.constants import HEADERS_TOTAL_COUNT, HEADERS_RETRY_AFTER
+from archivist.constants import HEADERS_RETRY_AFTER, HEADERS_TOTAL_COUNT
 from archivist.errors import (
     ArchivistBadRequestError,
     ArchivistError,
@@ -17,7 +17,6 @@ from archivist.errors import (
 from archivist.logger import set_logger
 
 from .mock_response import MockResponse
-
 
 # pylint: disable=unused-variable
 # pylint: disable=missing-docstring
@@ -58,7 +57,7 @@ class TestArchivist(TestCase):
         Test illegal url
         """
         with self.assertRaises(ArchivistError):
-            arch = Archivist("https://app.rkvst.io/", "authauthauth")
+            Archivist("https://app.rkvst.io/", "authauthauth")
 
     def test_archivist(self):
         """
@@ -161,7 +160,7 @@ class TestArchivist(TestCase):
                 msg="verify must be True",
             )
             with self.assertRaises(AttributeError):
-                e = arch.Illegal_endpoint
+                arch.Illegal_endpoint
 
     def test_archivist_token(self):
         """
@@ -169,14 +168,13 @@ class TestArchivist(TestCase):
         """
         with Archivist(
             "https://app.rkvst.io", (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET)
-        ) as arch:
-            with mock.patch.object(arch.appidp, "token") as mock_token:
-                mock_token.return_value = RESPONSE
-                self.assertEqual(
-                    arch.auth,
-                    ACCESS_TOKEN,
-                    msg="Incorrect auth",
-                )
+        ) as arch, mock.patch.object(arch.appidp, "token") as mock_token:
+            mock_token.return_value = RESPONSE
+            self.assertEqual(
+                arch.auth,
+                ACCESS_TOKEN,
+                msg="Incorrect auth",
+            )
 
     def test_archivist_none_token(self):
         """
@@ -194,11 +192,10 @@ class TestArchivist(TestCase):
         """
         with Archivist(
             "https://app.rkvst.io", (RKVST_APPREG_CLIENT, RKVST_APPREG_SECRET)
-        ) as arch:
-            with mock.patch.object(arch.appidp, "token") as mock_token:
-                mock_token.return_value = NONE_RESPONSE
-                with self.assertRaises(ArchivistError):
-                    _ = arch.auth
+        ) as arch, mock.patch.object(arch.appidp, "token") as mock_token:
+            mock_token.return_value = NONE_RESPONSE
+            with self.assertRaises(ArchivistError):
+                _ = arch.auth
 
     def test_archivist_copy(self):
         """
@@ -257,7 +254,7 @@ class TestArchivistPatch(TestArchivistMethods):
         request = {"field1": "value1"}
         with mock.patch.object(self.arch.session, "patch") as mock_patch:
             mock_patch.return_value = MockResponse(200, request=request)
-            resp = self.arch.patch("path/path/entity/xxxx", request)
+            self.arch.patch("path/path/entity/xxxx", request)
             args, kwargs = mock_patch.call_args
             self.assertEqual(
                 args,
@@ -286,7 +283,7 @@ class TestArchivistPatch(TestArchivistMethods):
                 400, request=request, field1="value1"
             )
             with self.assertRaises(ArchivistBadRequestError):
-                resp = self.arch.patch("path/path/entity/xxxx", request)
+                self.arch.patch("path/path/entity/xxxx", request)
 
     def test_patch_with_headers(self):
         """
@@ -295,7 +292,7 @@ class TestArchivistPatch(TestArchivistMethods):
         request = {"field1": "value1"}
         with mock.patch.object(self.arch.session, "patch") as mock_patch:
             mock_patch.return_value = MockResponse(200, request=request)
-            resp = self.arch.patch(
+            self.arch.patch(
                 "path/path/entity/xxxx",
                 request,
                 headers={"headerfield1": "headervalue1"},
@@ -327,7 +324,7 @@ class TestArchivistPatch(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "patch") as mock_patch:
             mock_patch.return_value = MockResponse(429, request=request)
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.patch(
+                self.arch.patch(
                     "path/path/id/xxxxxxxx",
                     request,
                 )
@@ -343,7 +340,7 @@ class TestArchivistPatch(TestArchivistMethods):
                 MockResponse(429, request=request),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.patch(
+                self.arch.patch(
                     "path/path/id/xxxxxxxx",
                     request,
                 )
@@ -361,7 +358,7 @@ class TestArchivistPatch(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}, request=request),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.patch(
+                self.arch.patch(
                     "path/path/id/xxxxxxxx",
                     request,
                 )
@@ -377,7 +374,7 @@ class TestArchivistPatch(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}, request=request),
                 MockResponse(200, request=request),
             )
-            resp = self.arch.patch("path/path/entity/xxxxxxxx", request)
+            self.arch.patch("path/path/entity/xxxxxxxx", request)
             args, kwargs = mock_patch.call_args
             self.assertEqual(
                 args,
@@ -437,7 +434,7 @@ class TestArchivistCount(TestArchivistMethods):
                 ],
             )
             with self.assertRaises(ArchivistBadRequestError):
-                count = self.arch.count("path/path")
+                self.arch.count("path/path")
 
     def test_count_with_missing_count_error(self):
         """
@@ -454,7 +451,7 @@ class TestArchivistCount(TestArchivistMethods):
                 ],
             )
             with self.assertRaises(ArchivistHeaderError):
-                count = self.arch.count("path/path")
+                self.arch.count("path/path")
 
     def test_count_with_429(self):
         """
@@ -463,7 +460,7 @@ class TestArchivistCount(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(429)
             with self.assertRaises(ArchivistTooManyRequestsError):
-                count = self.arch.count("path/path")
+                self.arch.count("path/path")
 
     def test_count_with_429_retry_and_fail(self):
         """
@@ -475,7 +472,7 @@ class TestArchivistCount(TestArchivistMethods):
                 MockResponse(429),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                count = self.arch.count("path/path")
+                self.arch.count("path/path")
 
     def test_count_with_429_retry_and_retries_fail(self):
         """
@@ -489,7 +486,7 @@ class TestArchivistCount(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                count = self.arch.count("path/path")
+                self.arch.count("path/path")
 
     def test_count_with_429_retry_and_success(self):
         """

--- a/unittests/testarchivistdelete.py
+++ b/unittests/testarchivistdelete.py
@@ -13,7 +13,6 @@ from archivist.errors import (
 
 from .mock_response import MockResponse
 
-
 # pylint: disable=unused-variable
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -42,7 +41,7 @@ class TestArchivistDelete(TestArchivistMethods):
         """
         with mock.patch.object(self.arch.session, "delete") as mock_delete:
             mock_delete.return_value = MockResponse(200)
-            resp = self.arch.delete("path/path/entity/xxxxxxxx")
+            self.arch.delete("path/path/entity/xxxxxxxx")
             self.assertEqual(
                 tuple(mock_delete.call_args),
                 (
@@ -64,7 +63,7 @@ class TestArchivistDelete(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "delete") as mock_delete:
             mock_delete.return_value = MockResponse(404, identity="entity/xxxxxxxx")
             with self.assertRaises(ArchivistNotFoundError):
-                resp = self.arch.delete("path/path/entity/xxxxxxxx")
+                self.arch.delete("path/path/entity/xxxxxxxx")
 
     def test_delete_with_headers(self):
         """
@@ -72,7 +71,7 @@ class TestArchivistDelete(TestArchivistMethods):
         """
         with mock.patch.object(self.arch.session, "delete") as mock_delete:
             mock_delete.return_value = MockResponse(200)
-            resp = self.arch.delete(
+            self.arch.delete(
                 "path/path/id/xxxxxxxx",
                 headers={"headerfield1": "headervalue1"},
             )
@@ -98,7 +97,7 @@ class TestArchivistDelete(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "delete") as mock_delete:
             mock_delete.return_value = MockResponse(429)
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.delete(
+                self.arch.delete(
                     "path/path/id/xxxxxxxx",
                     headers={"headerfield1": "headervalue1"},
                 )
@@ -113,7 +112,7 @@ class TestArchivistDelete(TestArchivistMethods):
                 MockResponse(429),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.delete("path/path/entity/xxxxxxxx")
+                self.arch.delete("path/path/entity/xxxxxxxx")
 
     def test_delete_with_429_retry_and_retries_fail(self):
         """
@@ -127,7 +126,7 @@ class TestArchivistDelete(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.delete("path/path/entity/xxxxxxxx")
+                self.arch.delete("path/path/entity/xxxxxxxx")
 
     def test_delete_with_429_retry_and_success(self):
         """
@@ -139,7 +138,7 @@ class TestArchivistDelete(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
                 MockResponse(200),
             )
-            resp = self.arch.delete("path/path/entity/xxxxxxxx")
+            self.arch.delete("path/path/entity/xxxxxxxx")
             self.assertEqual(
                 tuple(mock_delete.call_args),
                 (

--- a/unittests/testarchivistget.py
+++ b/unittests/testarchivistget.py
@@ -14,7 +14,6 @@ from archivist.errors import (
 
 from .mock_response import MockResponse
 
-
 # pylint: disable=unused-variable
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -43,7 +42,7 @@ class TestArchivistGet(TestArchivistMethods):
         """
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200)
-            resp = self.arch.get("path/path/entity/xxxxxxxx")
+            self.arch.get("path/path/entity/xxxxxxxx")
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -65,7 +64,7 @@ class TestArchivistGet(TestArchivistMethods):
         """
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200)
-            resp = self.arch.get("path/path/entity/xxxxxxxx")
+            self.arch.get("path/path/entity/xxxxxxxx")
             last_response = self.arch.last_response()
             self.assertEqual(last_response, [mock_get.return_value])
 
@@ -76,7 +75,7 @@ class TestArchivistGet(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
             with self.assertRaises(ArchivistNotFoundError):
-                resp = self.arch.get("path/path/entity/xxxxxxxx")
+                self.arch.get("path/path/entity/xxxxxxxx")
 
     def test_get_with_headers(self):
         """
@@ -84,7 +83,7 @@ class TestArchivistGet(TestArchivistMethods):
         """
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200)
-            resp = self.arch.get(
+            self.arch.get(
                 "path/path/id/xxxxxxxx",
                 headers={"headerfield1": "headervalue1"},
             )
@@ -111,7 +110,7 @@ class TestArchivistGet(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(429)
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.get(
+                self.arch.get(
                     "path/path/id/xxxxxxxx",
                     headers={"headerfield1": "headervalue1"},
                 )
@@ -126,7 +125,7 @@ class TestArchivistGet(TestArchivistMethods):
                 MockResponse(429),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.get("path/path/entity/xxxxxxxx")
+                self.arch.get("path/path/entity/xxxxxxxx")
 
     def test_get_with_429_retry_and_retries_fail(self):
         """
@@ -140,7 +139,7 @@ class TestArchivistGet(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.get("path/path/entity/xxxxxxxx")
+                self.arch.get("path/path/entity/xxxxxxxx")
 
     def test_get_with_429_retry_and_success(self):
         """
@@ -152,7 +151,7 @@ class TestArchivistGet(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
                 MockResponse(200),
             )
-            resp = self.arch.get("path/path/entity/xxxxxxxx")
+            self.arch.get("path/path/entity/xxxxxxxx")
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -202,7 +201,7 @@ class TestArchivistGetFile(TestArchivistMethods):
                 iter_content=iter_content(),
             )
             with BytesIO() as fd:
-                resp = self.arch.get_file("path/path/entity/xxxxxxxx", fd)
+                self.arch.get_file("path/path/entity/xxxxxxxx", fd)
                 self.assertEqual(
                     tuple(mock_get.call_args),
                     (
@@ -225,9 +224,8 @@ class TestArchivistGetFile(TestArchivistMethods):
         """
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
-            with self.assertRaises(ArchivistNotFoundError):
-                with BytesIO() as fd:
-                    resp = self.arch.get_file("path/path/entity/xxxxxxxx", fd)
+            with self.assertRaises(ArchivistNotFoundError), BytesIO() as fd:
+                self.arch.get_file("path/path/entity/xxxxxxxx", fd)
 
     def test_get_file_with_429(self):
         """
@@ -235,9 +233,8 @@ class TestArchivistGetFile(TestArchivistMethods):
         """
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(429)
-            with self.assertRaises(ArchivistTooManyRequestsError):
-                with BytesIO() as fd:
-                    resp = self.arch.get_file("path/path/entity/xxxxxxxx", fd)
+            with self.assertRaises(ArchivistTooManyRequestsError), BytesIO() as fd:
+                self.arch.get_file("path/path/entity/xxxxxxxx", fd)
 
     def test_get_file_with_429_retry_and_fail(self):
         """
@@ -248,9 +245,8 @@ class TestArchivistGetFile(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
                 MockResponse(429),
             )
-            with self.assertRaises(ArchivistTooManyRequestsError):
-                with BytesIO() as fd:
-                    resp = self.arch.get_file("path/path/entity/xxxxxxxx", fd)
+            with self.assertRaises(ArchivistTooManyRequestsError), BytesIO() as fd:
+                self.arch.get_file("path/path/entity/xxxxxxxx", fd)
 
     def test_get_file_with_429_retry_and_retries_fail(self):
         """
@@ -263,9 +259,8 @@ class TestArchivistGetFile(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
-            with self.assertRaises(ArchivistTooManyRequestsError):
-                with BytesIO() as fd:
-                    resp = self.arch.get_file("path/path/entity/xxxxxxxx", fd)
+            with self.assertRaises(ArchivistTooManyRequestsError), BytesIO() as fd:
+                self.arch.get_file("path/path/entity/xxxxxxxx", fd)
 
     def test_get_file_with_429_retry_and_success(self):
         """
@@ -299,7 +294,7 @@ class TestArchivistGetFile(TestArchivistMethods):
                 ),
             )
             with BytesIO() as fd:
-                resp = self.arch.get_file("path/path/entity/xxxxxxxx", fd)
+                self.arch.get_file("path/path/entity/xxxxxxxx", fd)
                 self.assertEqual(
                     tuple(mock_get.call_args),
                     (

--- a/unittests/testarchivistlist.py
+++ b/unittests/testarchivistlist.py
@@ -5,7 +5,7 @@ Test archivist list
 from os import environ
 from unittest import mock
 
-from archivist.constants import HEADERS_TOTAL_COUNT, HEADERS_RETRY_AFTER
+from archivist.constants import HEADERS_RETRY_AFTER, HEADERS_TOTAL_COUNT
 from archivist.errors import (
     ArchivistBadFieldError,
     ArchivistBadRequestError,
@@ -15,7 +15,6 @@ from archivist.logger import set_logger
 
 from .mock_response import MockResponse
 from .testarchivist import TestArchivistMethods
-
 
 # pylint: disable=unused-variable
 # pylint: disable=missing-docstring
@@ -79,7 +78,7 @@ class TestArchivistList(TestArchivistMethods):
                 ],
             )
             with self.assertRaises(ArchivistBadRequestError):
-                responses = list(self.arch.list("path/path", "things"))
+                list(self.arch.list("path/path", "things"))
 
     def test_list_with_bad_field(self):
         """
@@ -95,7 +94,7 @@ class TestArchivistList(TestArchivistMethods):
                 ],
             )
             with self.assertRaises(ArchivistBadFieldError):
-                responses = list(self.arch.list("path/path", "badthings"))
+                list(self.arch.list("path/path", "badthings"))
 
     def test_list_with_headers(self):
         """
@@ -378,7 +377,7 @@ class TestArchivistList(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(429)
             with self.assertRaises(ArchivistTooManyRequestsError):
-                things = list(self.arch.list("path/path", "things"))
+                list(self.arch.list("path/path", "things"))
 
     def test_list_with_429_retry_and_fail(self):
         """
@@ -390,7 +389,7 @@ class TestArchivistList(TestArchivistMethods):
                 MockResponse(429),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                things = list(self.arch.list("path/path", "things"))
+                list(self.arch.list("path/path", "things"))
 
     def test_list_with_429_retry_and_retries_fail(self):
         """
@@ -404,7 +403,7 @@ class TestArchivistList(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                things = list(self.arch.list("path/path", "things"))
+                list(self.arch.list("path/path", "things"))
 
     def test_list_with_429_retry_and_success(self):
         """

--- a/unittests/testarchivistpost.py
+++ b/unittests/testarchivistpost.py
@@ -14,7 +14,6 @@ from archivist.errors import (
 
 from .mock_response import MockResponse
 
-
 # pylint: disable=unused-variable
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -44,7 +43,7 @@ class TestArchivistPost(TestArchivistMethods):
         request = {"field1": "value1"}
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, request=request)
-            resp = self.arch.post("path/path", request)
+            self.arch.post("path/path", request)
             args, kwargs = mock_post.call_args
             self.assertEqual(
                 args,
@@ -71,7 +70,7 @@ class TestArchivistPost(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(400, request=request, field1="value1")
             with self.assertRaises(ArchivistBadRequestError):
-                resp = self.arch.post("path/path", request)
+                self.arch.post("path/path", request)
 
     def test_post_with_429(self):
         """
@@ -81,7 +80,7 @@ class TestArchivistPost(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(429, request=request, field1="value1")
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.post("path/path", request)
+                self.arch.post("path/path", request)
 
     def test_post_with_429_retry_and_fail(self):
         """
@@ -94,7 +93,7 @@ class TestArchivistPost(TestArchivistMethods):
                 MockResponse(429),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.post("path/path", request)
+                self.arch.post("path/path", request)
 
     def test_post_with_429_retry_and_retries_fail(self):
         """
@@ -109,7 +108,7 @@ class TestArchivistPost(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.post("path/path", request)
+                self.arch.post("path/path", request)
 
     def test_post_with_429_retry_and_success(self):
         """
@@ -122,7 +121,7 @@ class TestArchivistPost(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
                 MockResponse(200),
             )
-            resp = self.arch.post("path/path", request)
+            self.arch.post("path/path", request)
             args, kwargs = mock_post.call_args
             self.assertEqual(
                 args,
@@ -148,7 +147,7 @@ class TestArchivistPost(TestArchivistMethods):
         request = {"field1": "value1"}
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, request=request)
-            resp = self.arch.post(
+            self.arch.post(
                 "path/path",
                 request,
                 headers={"headerfield1": "headervalue1"},
@@ -178,7 +177,7 @@ class TestArchivistPost(TestArchivistMethods):
         """
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200)
-            resp = self.arch.post_file(
+            self.arch.post_file(
                 "path/path",
                 BytesIO(b"lotsofbytes"),
                 "image/jpg",
@@ -242,7 +241,7 @@ class TestArchivistPost(TestArchivistMethods):
         """
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200)
-            resp = self.arch.post_file(
+            self.arch.post_file(
                 "path/path",
                 BytesIO(b"lotsofbytes"),
                 "image/jpg",
@@ -308,7 +307,7 @@ class TestArchivistPost(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(400)
             with self.assertRaises(ArchivistBadRequestError):
-                resp = self.arch.post_file(
+                self.arch.post_file(
                     "path/path",
                     BytesIO(b"lotsofbytes"),
                     "image/jpg",
@@ -321,7 +320,7 @@ class TestArchivistPost(TestArchivistMethods):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(429)
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.post_file(
+                self.arch.post_file(
                     "path/path",
                     BytesIO(b"lotsofbytes"),
                     "image/jpg",
@@ -337,7 +336,7 @@ class TestArchivistPost(TestArchivistMethods):
                 MockResponse(429),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.post_file(
+                self.arch.post_file(
                     "path/path",
                     BytesIO(b"lotsofbytes"),
                     "image/jpg",
@@ -355,7 +354,7 @@ class TestArchivistPost(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.arch.post_file(
+                self.arch.post_file(
                     "path/path",
                     BytesIO(b"lotsofbytes"),
                     "image/jpg",
@@ -372,7 +371,7 @@ class TestArchivistPost(TestArchivistMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
                 MockResponse(200),
             )
-            resp = self.arch.post_file(
+            self.arch.post_file(
                 "path/path",
                 BytesIO(b"lotsofbytes"),
                 "image/jpg",
@@ -446,7 +445,7 @@ class TestArchivistPostWithoutAuth(TestCase):
         request = {"field1": "value1"}
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, request=request)
-            resp = self.arch.post("path/path", request)
+            self.arch.post("path/path", request)
             args, kwargs = mock_post.call_args
             self.assertEqual(
                 args,

--- a/unittests/testarchivistsignature.py
+++ b/unittests/testarchivistsignature.py
@@ -15,7 +15,6 @@ from archivist.logger import set_logger
 from .mock_response import MockResponse
 from .testarchivist import TestArchivistMethods
 
-
 # pylint: disable=unused-variable
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -42,9 +41,7 @@ class TestArchivistSignature(TestArchivistMethods):
                     },
                 ],
             )
-            entity = self.arch.get_by_signature(
-                "path/path", "things", {"field1": "value1"}
-            )
+            self.arch.get_by_signature("path/path", "things", {"field1": "value1"})
             for a in mock_get.call_args_list:
                 self.assertEqual(
                     tuple(a),
@@ -71,9 +68,7 @@ class TestArchivistSignature(TestArchivistMethods):
                 things=[],
             )
             with self.assertRaises(ArchivistNotFoundError):
-                entity = self.arch.get_by_signature(
-                    "path/path", "things", {"field1": "value1"}
-                )
+                self.arch.get_by_signature("path/path", "things", {"field1": "value1"})
 
     def test_get_by_signature_duplicate(self):
         """
@@ -92,9 +87,7 @@ class TestArchivistSignature(TestArchivistMethods):
                 ],
             )
             with self.assertRaises(ArchivistDuplicateError):
-                entity = self.arch.get_by_signature(
-                    "path/path", "things", {"field1": "value1"}
-                )
+                self.arch.get_by_signature("path/path", "things", {"field1": "value1"})
 
     def test_get_by_signature_with_bad_field(self):
         """
@@ -110,6 +103,6 @@ class TestArchivistSignature(TestArchivistMethods):
                 ],
             )
             with self.assertRaises(ArchivistBadFieldError):
-                entity = self.arch.get_by_signature(
+                self.arch.get_by_signature(
                     "path/path", "badthings", {"field1": "value1"}
                 )

--- a/unittests/testassetattachments.py
+++ b/unittests/testassetattachments.py
@@ -7,11 +7,11 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.constants import (
-    ROOT,
-    ASSETS_LABEL,
-    ATTACHMENTS_LABEL,
     ASSETATTACHMENTS_LABEL,
     ASSETATTACHMENTS_SUBPATH,
+    ASSETS_LABEL,
+    ATTACHMENTS_LABEL,
+    ROOT,
 )
 
 from .mock_response import MockResponse

--- a/unittests/testassets.py
+++ b/unittests/testassets.py
@@ -5,7 +5,6 @@ Test assets
 from copy import copy
 from logging import getLogger
 from os import environ
-
 from unittest import mock
 
 from archivist.constants import (
@@ -18,35 +17,34 @@ from archivist.logger import set_logger
 
 from .mock_response import MockResponse
 from .testassetsconstants import (
-    TestAssetsBase,
-    TestAssetsBaseConfirm,
-    PRIMARY_IMAGE,
     ASSET_NAME,
     ATTRS,
-    SUBPATH,
-    PROPS,
     FIXTURES,
+    PRIMARY_IMAGE,
+    PROPS,
     REQUEST_EXISTS,
     REQUEST_EXISTS_ATTACHMENTS,
-    REQUEST_EXISTS_LOCATION,
-    REQUEST_EXISTS_LOCATION_IDENTITY,
     REQUEST_EXISTS_KWARGS,
     REQUEST_EXISTS_KWARGS_ATTACHMENTS,
     REQUEST_EXISTS_KWARGS_LOCATION,
-    REQUEST_KWARGS,
+    REQUEST_EXISTS_LOCATION,
+    REQUEST_EXISTS_LOCATION_IDENTITY,
     REQUEST_FIXTURES_KWARGS,
+    REQUEST_KWARGS,
     RESPONSE,
     RESPONSE_ATTACHMENTS,
-    RESPONSE_LOCATION,
     RESPONSE_EXISTS,
     RESPONSE_EXISTS_ATTACHMENTS,
     RESPONSE_EXISTS_LOCATION,
+    RESPONSE_FAILED,
     RESPONSE_FIXTURES,
+    RESPONSE_LOCATION,
     RESPONSE_NO_CONFIRMATION,
     RESPONSE_PENDING,
-    RESPONSE_FAILED,
+    SUBPATH,
+    TestAssetsBase,
+    TestAssetsBaseConfirm,
 )
-
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -151,7 +149,7 @@ class TestAssetsCreate(TestAssetsBase):
             mock_get.return_value = MockResponse(200, **RESPONSE_NO_CONFIRMATION)
 
             with self.assertRaises(ArchivistUnconfirmedError):
-                asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+                self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
 
     def test_assets_create_with_confirmation_failed_status(self):
         """
@@ -166,7 +164,7 @@ class TestAssetsCreate(TestAssetsBase):
                 MockResponse(200, **RESPONSE_FAILED),
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
-                asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+                self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
 
     def test_assets_create_with_confirmation_always_pending_status(self):
         """
@@ -186,7 +184,7 @@ class TestAssetsCreate(TestAssetsBase):
                 MockResponse(200, **RESPONSE_PENDING),
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
-                asset = self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
+                self.arch.assets.create(props=PROPS, attrs=ATTRS, confirm=True)
 
 
 class TestAssetsCreateConfirm(TestAssetsBaseConfirm):

--- a/unittests/testassetslist.py
+++ b/unittests/testassetslist.py
@@ -4,7 +4,6 @@ Test assets list
 
 from logging import getLogger
 from os import environ
-
 from unittest import mock
 
 from archivist.constants import (
@@ -14,9 +13,9 @@ from archivist.logger import set_logger
 
 from .mock_response import MockResponse
 from .testassetsconstants import (
-    TestAssetsBase,
-    SUBPATH,
     RESPONSE,
+    SUBPATH,
+    TestAssetsBase,
 )
 
 # pylint: disable=missing-docstring

--- a/unittests/testassetsread.py
+++ b/unittests/testassetsread.py
@@ -4,7 +4,6 @@ Test assets read
 
 from logging import getLogger
 from os import environ
-
 from unittest import mock
 
 from archivist.constants import (
@@ -17,11 +16,11 @@ from archivist.logger import set_logger
 
 from .mock_response import MockResponse
 from .testassetsconstants import (
-    TestAssetsBase,
     IDENTITY,
-    SUBPATH,
     RESPONSE,
     RESPONSE_NO_ATTACHMENTS,
+    SUBPATH,
+    TestAssetsBase,
 )
 
 PUBLICURL = (
@@ -93,7 +92,7 @@ class TestAssetsRead(TestAssetsBase):
             mock_get.return_value = MockResponse(200, **RESPONSE_BAD_PUBLICURL)
 
             with self.assertRaises(ArchivistBadFieldError):
-                publicurl = self.arch.assets.publicurl(IDENTITY)
+                self.arch.assets.publicurl(IDENTITY)
 
 
 class TestAssetsCount(TestAssetsBase):
@@ -149,7 +148,7 @@ class TestAssetsCount(TestAssetsBase):
                 ],
             )
 
-            count = self.arch.assets.count(
+            self.arch.assets.count(
                 props={
                     "confirmation_status": "CONFIRMED",
                 },
@@ -186,7 +185,7 @@ class TestAssetsCount(TestAssetsBase):
                 ],
             )
 
-            count = self.arch.assets.count(
+            self.arch.assets.count(
                 attrs={"arc_firmware_version": "1.0"},
             )
             self.assertEqual(

--- a/unittests/testassetswait.py
+++ b/unittests/testassetswait.py
@@ -4,7 +4,6 @@ Test assets wait
 
 from logging import getLogger
 from os import environ
-
 from unittest import mock
 
 from archivist.constants import (
@@ -17,12 +16,11 @@ from archivist.logger import set_logger
 
 from .mock_response import MockResponse
 from .testassetsconstants import (
-    TestAssetsBase,
-    SUBPATH,
-    RESPONSE_PENDING,
     RESPONSE_FAILED,
+    RESPONSE_PENDING,
+    SUBPATH,
+    TestAssetsBase,
 )
-
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access

--- a/unittests/testattachments.py
+++ b/unittests/testattachments.py
@@ -7,9 +7,9 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.constants import (
-    ROOT,
-    ATTACHMENTS_SUBPATH,
     ATTACHMENTS_LABEL,
+    ATTACHMENTS_SUBPATH,
+    ROOT,
 )
 
 from .mock_response import MockResponse

--- a/unittests/testcompliance.py
+++ b/unittests/testcompliance.py
@@ -8,10 +8,10 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.constants import (
-    ROOT,
-    COMPLIANCE_SUBPATH,
     COMPLIANCE_LABEL,
     COMPLIANCE_POLICIES_LABEL,
+    COMPLIANCE_SUBPATH,
+    ROOT,
 )
 from archivist.logger import set_logger
 

--- a/unittests/testcompliance_policies.py
+++ b/unittests/testcompliance_policies.py
@@ -5,23 +5,22 @@ Test compliance policies
 from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
-from archivist.constants import (
-    ROOT,
-    HEADERS_REQUEST_TOTAL_COUNT,
-    HEADERS_TOTAL_COUNT,
-    COMPLIANCE_POLICIES_SUBPATH,
-    COMPLIANCE_POLICIES_LABEL,
-)
-from archivist.errors import ArchivistBadRequestError
 from archivist.compliance_policies import (
     CompliancePolicy,
 )
 from archivist.compliance_policy_requests import (
     CompliancePolicySince,
 )
+from archivist.constants import (
+    COMPLIANCE_POLICIES_LABEL,
+    COMPLIANCE_POLICIES_SUBPATH,
+    HEADERS_REQUEST_TOTAL_COUNT,
+    HEADERS_TOTAL_COUNT,
+    ROOT,
+)
+from archivist.errors import ArchivistBadRequestError
 
 from .mock_response import MockResponse
-
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -142,7 +141,7 @@ class TestCompliancePolicies(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200, **SINCE_RESPONSE)
 
-            compliance_policy = self.arch.compliance_policies.read(IDENTITY)
+            self.arch.compliance_policies.read(IDENTITY)
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -165,7 +164,7 @@ class TestCompliancePolicies(TestCase):
         with mock.patch.object(self.arch.session, "delete") as mock_delete:
             mock_delete.return_value = MockResponse(200, {})
 
-            compliance_policy = self.arch.compliance_policies.delete(IDENTITY)
+            self.arch.compliance_policies.delete(IDENTITY)
             self.assertEqual(
                 tuple(mock_delete.call_args),
                 (
@@ -187,7 +186,7 @@ class TestCompliancePolicies(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(400)
             with self.assertRaises(ArchivistBadRequestError):
-                resp = self.arch.compliance_policies.read(IDENTITY)
+                self.arch.compliance_policies.read(IDENTITY)
 
     def test_compliance_policies_count(self):
         """
@@ -237,7 +236,7 @@ class TestCompliancePolicies(TestCase):
                 ],
             )
 
-            count = self.arch.compliance_policies.count(
+            self.arch.compliance_policies.count(
                 props={"compliance_type": "SINCE"},
             )
             self.assertEqual(

--- a/unittests/testerrors.py
+++ b/unittests/testerrors.py
@@ -7,13 +7,11 @@ Test errors
 # pylint: disable=too-few-public-methods
 
 import json
-
 from unittest import TestCase
 
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 from archivist.errors import (
-    _parse_response,
     Archivist4xxError,
     Archivist5xxError,
     ArchivistBadRequestError,
@@ -25,6 +23,7 @@ from archivist.errors import (
     ArchivistTooManyRequestsError,
     ArchivistUnauthenticatedError,
     ArchivistUnavailableError,
+    _parse_response,
 )
 
 from .mock_response import MockResponse

--- a/unittests/testevents.py
+++ b/unittests/testevents.py
@@ -5,22 +5,22 @@ Test events
 from unittest import TestCase, mock
 
 from archivist.constants import (
-    ROOT,
     ASSETS_LABEL,
     ASSETS_SUBPATH,
     EVENTS_LABEL,
+    ROOT,
 )
 from archivist.events import Event
 
 from .mock_response import MockResponse
 from .testeventsconstants import (
-    TestEventsBase,
     IDENTITY,
     RESPONSE,
     RESPONSE_WITH_NO_PRINCIPAL,
+    RESPONSE_WITH_NO_TIMESTAMP,
     RESPONSE_WITH_PRINCIPAL_DECLARED,
     RESPONSE_WITH_TIMESTAMP_ACCEPTED,
-    RESPONSE_WITH_NO_TIMESTAMP,
+    TestEventsBase,
 )
 
 # pylint: disable=missing-docstring

--- a/unittests/testeventscount.py
+++ b/unittests/testeventscount.py
@@ -5,20 +5,20 @@ Test events count
 from unittest import mock
 
 from archivist.constants import (
-    ROOT,
     ASSETS_LABEL,
-    ASSETS_WILDCARD,
     ASSETS_SUBPATH,
+    ASSETS_WILDCARD,
     EVENTS_LABEL,
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
+    ROOT,
 )
 
 from .mock_response import MockResponse
 from .testeventsconstants import (
-    TestEventsBase,
     ASSET_ID,
     RESPONSE,
+    TestEventsBase,
 )
 
 # pylint: disable=missing-docstring
@@ -86,7 +86,7 @@ class TestEventsCount(TestEventsBase):
                 ],
             )
 
-            count = self.arch.events.count(
+            self.arch.events.count(
                 asset_id=ASSET_ID,
                 props={
                     "confirmation_status": "CONFIRMED",
@@ -127,7 +127,7 @@ class TestEventsCount(TestEventsBase):
                 ],
             )
 
-            count = self.arch.events.count(
+            self.arch.events.count(
                 asset_id=ASSET_ID,
                 attrs={"arc_firmware_version": "1.0"},
             )
@@ -169,7 +169,7 @@ class TestEventsCount(TestEventsBase):
                 ],
             )
 
-            count = self.arch.events.count(
+            self.arch.events.count(
                 attrs={"arc_firmware_version": "1.0"},
             )
             self.assertEqual(

--- a/unittests/testeventscreate.py
+++ b/unittests/testeventscreate.py
@@ -5,10 +5,10 @@ Test events create
 from unittest import mock
 
 from archivist.constants import (
-    ROOT,
     ASSETS_LABEL,
     ASSETS_SUBPATH,
     EVENTS_LABEL,
+    ROOT,
 )
 from archivist.errors import (
     ArchivistUnconfirmedError,
@@ -16,34 +16,34 @@ from archivist.errors import (
 
 from .mock_response import MockResponse
 from .testeventsconstants import (
-    TestEventsBase,
-    ASSET_ID,
-    PROPS,
-    LOCATION,
-    EVENT_ATTRS,
     ASSET_ATTRS,
+    ASSET_ID,
     ATTACHMENTS,
+    EVENT_ATTRS,
     EVENT_ATTRS_ATTACHMENTS,
-    REQUEST_WITH_ATTACHMENTS,
-    RESPONSE_WITH_ATTACHMENTS,
-    SBOM_RESULT,
-    EVENT_ATTRS_SBOM,
-    REQUEST_WITH_SBOM,
-    RESPONSE_WITH_SBOM,
-    EVENT_ATTRS_SBOMATTACHMENT,
-    REQUEST_WITH_SBOMATTACHMENT,
-    RESPONSE_WITH_SBOMATTACHMENT,
     EVENT_ATTRS_LOCATION,
     EVENT_ATTRS_LOCATION_IDENTITY,
-    REQUEST_WITH_LOCATION,
-    RESPONSE_WITH_LOCATION,
+    EVENT_ATTRS_SBOM,
+    EVENT_ATTRS_SBOMATTACHMENT,
+    LOCATION,
+    PROPS,
     REQUEST,
     REQUEST_WITH_ASSET_ATTRS,
+    REQUEST_WITH_ATTACHMENTS,
+    REQUEST_WITH_LOCATION,
+    REQUEST_WITH_SBOM,
+    REQUEST_WITH_SBOMATTACHMENT,
     RESPONSE,
-    RESPONSE_WITH_ASSET_ATTRS,
+    RESPONSE_FAILED,
     RESPONSE_NO_CONFIRMATION,
     RESPONSE_PENDING,
-    RESPONSE_FAILED,
+    RESPONSE_WITH_ASSET_ATTRS,
+    RESPONSE_WITH_ATTACHMENTS,
+    RESPONSE_WITH_LOCATION,
+    RESPONSE_WITH_SBOM,
+    RESPONSE_WITH_SBOMATTACHMENT,
+    SBOM_RESULT,
+    TestEventsBase,
 )
 
 # pylint: disable=missing-docstring
@@ -289,9 +289,7 @@ class TestEventsCreate(TestEventsBase):
         """
         with mock.patch.object(
             self.arch.session, "post"
-        ) as mock_post, mock.patch.object(
-            self.arch.locations, "create_if_not_exists"
-        ) as mock_location_create:
+        ) as mock_post, mock.patch.object(self.arch.locations, "create_if_not_exists"):
             mock_post.return_value = MockResponse(200, **RESPONSE_WITH_LOCATION)
 
             event = self.arch.events.create_from_data(
@@ -398,9 +396,7 @@ class TestEventsCreate(TestEventsBase):
             mock_get.return_value = MockResponse(200, **RESPONSE_NO_CONFIRMATION)
 
             with self.assertRaises(ArchivistUnconfirmedError):
-                event = self.arch.events.create(
-                    ASSET_ID, PROPS, EVENT_ATTRS, confirm=True
-                )
+                self.arch.events.create(ASSET_ID, PROPS, EVENT_ATTRS, confirm=True)
 
     def test_events_create_with_confirmation_failed_status(self):
         """
@@ -415,9 +411,7 @@ class TestEventsCreate(TestEventsBase):
                 MockResponse(200, **RESPONSE_FAILED),
             ]
             with self.assertRaises(ArchivistUnconfirmedError):
-                event = self.arch.events.create(
-                    ASSET_ID, PROPS, EVENT_ATTRS, confirm=True
-                )
+                self.arch.events.create(ASSET_ID, PROPS, EVENT_ATTRS, confirm=True)
 
     def test_events_create_with_confirmation_always_pending_status(self):
         """
@@ -438,6 +432,4 @@ class TestEventsCreate(TestEventsBase):
             ]
 
             with self.assertRaises(ArchivistUnconfirmedError):
-                event = self.arch.events.create(
-                    ASSET_ID, PROPS, EVENT_ATTRS, confirm=True
-                )
+                self.arch.events.create(ASSET_ID, PROPS, EVENT_ATTRS, confirm=True)

--- a/unittests/testeventslist.py
+++ b/unittests/testeventslist.py
@@ -5,18 +5,18 @@ Test events list
 from unittest import mock
 
 from archivist.constants import (
-    ROOT,
     ASSETS_LABEL,
-    ASSETS_WILDCARD,
     ASSETS_SUBPATH,
+    ASSETS_WILDCARD,
     EVENTS_LABEL,
+    ROOT,
 )
 
 from .mock_response import MockResponse
 from .testeventsconstants import (
-    TestEventsBase,
     ASSET_ID,
     RESPONSE,
+    TestEventsBase,
 )
 
 # pylint: disable=missing-docstring

--- a/unittests/testeventsread.py
+++ b/unittests/testeventsread.py
@@ -5,23 +5,22 @@ Test events read
 from unittest import mock
 
 from archivist.constants import (
-    ROOT,
     ASSETS_LABEL,
     ASSETS_SUBPATH,
     EVENTS_LABEL,
+    ROOT,
 )
 from archivist.errors import ArchivistBadFieldError
 
 from .mock_response import MockResponse
 from .testeventsconstants import (
-    TestEventsBase,
-    RESPONSE,
     IDENTITY,
     PUBLICURL,
-    RESPONSE_PUBLICURL,
+    RESPONSE,
     RESPONSE_BAD_PUBLICURL,
+    RESPONSE_PUBLICURL,
+    TestEventsBase,
 )
-
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -104,4 +103,4 @@ class TestEventsRead(TestEventsBase):
             mock_get.return_value = MockResponse(200, **RESPONSE_BAD_PUBLICURL)
 
             with self.assertRaises(ArchivistBadFieldError):
-                publicurl = self.arch.events.publicurl(IDENTITY)
+                self.arch.events.publicurl(IDENTITY)

--- a/unittests/testeventswait.py
+++ b/unittests/testeventswait.py
@@ -5,12 +5,12 @@ Test events wait
 from unittest import mock
 
 from archivist.constants import (
-    ROOT,
-    ASSETS_WILDCARD,
     ASSETS_SUBPATH,
+    ASSETS_WILDCARD,
     EVENTS_LABEL,
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
+    ROOT,
 )
 from archivist.errors import (
     ArchivistNotFoundError,
@@ -18,8 +18,8 @@ from archivist.errors import (
 
 from .mock_response import MockResponse
 from .testeventsconstants import (
-    TestEventsBase,
     RESPONSE_PENDING,
+    TestEventsBase,
 )
 
 # pylint: disable=missing-docstring

--- a/unittests/testfixtures.py
+++ b/unittests/testfixtures.py
@@ -3,11 +3,9 @@ Test archivist fixtures
 """
 
 from copy import copy
-
 from unittest import TestCase
 
 from archivist.archivist import Archivist
-
 
 # pylint: disable=missing-docstring
 

--- a/unittests/testlocations.py
+++ b/unittests/testlocations.py
@@ -6,11 +6,11 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.constants import (
-    ROOT,
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
-    LOCATIONS_SUBPATH,
     LOCATIONS_LABEL,
+    LOCATIONS_SUBPATH,
+    ROOT,
 )
 from archivist.errors import ArchivistBadRequestError, ArchivistNotFoundError
 from archivist.locations import Location
@@ -340,7 +340,7 @@ class TestLocations(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200, **RESPONSE)
 
-            asset = self.arch.locations.read(IDENTITY)
+            self.arch.locations.read(IDENTITY)
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -363,7 +363,7 @@ class TestLocations(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(400)
             with self.assertRaises(ArchivistBadRequestError):
-                resp = self.arch.locations.read(IDENTITY)
+                self.arch.locations.read(IDENTITY)
 
     def test_locations_count(self):
         """
@@ -413,7 +413,7 @@ class TestLocations(TestCase):
                 ],
             )
 
-            count = self.arch.locations.count(
+            self.arch.locations.count(
                 props={"display_name": "Macclesfield, Cheshire"},
             )
             self.assertEqual(
@@ -448,7 +448,7 @@ class TestLocations(TestCase):
                 ],
             )
 
-            count = self.arch.locations.count(
+            self.arch.locations.count(
                 attrs={"director": "John Smith"},
             )
             self.assertEqual(

--- a/unittests/testpublic.py
+++ b/unittests/testpublic.py
@@ -6,17 +6,16 @@ from copy import copy
 from os import environ
 from unittest import TestCase, mock
 
-from archivist.constants import HEADERS_TOTAL_COUNT, HEADERS_RETRY_AFTER
+from archivist.archivistpublic import ArchivistPublic
+from archivist.constants import HEADERS_RETRY_AFTER, HEADERS_TOTAL_COUNT
 from archivist.errors import (
     ArchivistBadRequestError,
     ArchivistHeaderError,
     ArchivistTooManyRequestsError,
 )
 from archivist.logger import set_logger
-from archivist.archivistpublic import ArchivistPublic
 
 from .mock_response import MockResponse
-
 
 # pylint: disable=unused-variable
 # pylint: disable=missing-docstring
@@ -62,7 +61,7 @@ class TestPublic(TestCase):
                 msg="public must be True",
             )
             with self.assertRaises(AttributeError):
-                e = public.Illegal_endpoint
+                public.Illegal_endpoint
 
     def test_public_copy(self):
         """
@@ -149,7 +148,7 @@ class TestPublicCount(TestPublicMethods):
                 ],
             )
             with self.assertRaises(ArchivistBadRequestError):
-                count = self.public.count("path/path")
+                self.public.count("path/path")
 
     def test_count_with_missing_count_error(self):
         """
@@ -166,7 +165,7 @@ class TestPublicCount(TestPublicMethods):
                 ],
             )
             with self.assertRaises(ArchivistHeaderError):
-                count = self.public.count("path/path")
+                self.public.count("path/path")
 
     def test_count_with_429(self):
         """
@@ -175,7 +174,7 @@ class TestPublicCount(TestPublicMethods):
         with mock.patch.object(self.public.session, "get") as mock_get:
             mock_get.return_value = MockResponse(429)
             with self.assertRaises(ArchivistTooManyRequestsError):
-                count = self.public.count("path/path")
+                self.public.count("path/path")
 
     def test_count_with_429_retry_and_fail(self):
         """
@@ -187,7 +186,7 @@ class TestPublicCount(TestPublicMethods):
                 MockResponse(429),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                count = self.public.count("path/path")
+                self.public.count("path/path")
 
     def test_count_with_429_retry_and_retries_fail(self):
         """
@@ -201,7 +200,7 @@ class TestPublicCount(TestPublicMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                count = self.public.count("path/path")
+                self.public.count("path/path")
 
     def test_count_with_429_retry_and_success(self):
         """

--- a/unittests/testpublicassetattachments.py
+++ b/unittests/testpublicassetattachments.py
@@ -9,11 +9,11 @@ from unittest import TestCase, mock
 
 from archivist.archivistpublic import ArchivistPublic
 from archivist.constants import (
-    ROOT,
-    ASSETS_LABEL,
-    ATTACHMENTS_LABEL,
     ASSETATTACHMENTS_LABEL,
     ASSETATTACHMENTS_SUBPATH,
+    ASSETS_LABEL,
+    ATTACHMENTS_LABEL,
+    ROOT,
 )
 from archivist.logger import set_logger
 

--- a/unittests/testpublicassetsread.py
+++ b/unittests/testpublicassetsread.py
@@ -4,7 +4,6 @@ Test public assets read
 
 from logging import getLogger
 from os import environ
-
 from unittest import mock
 
 from archivist.constants import (
@@ -20,7 +19,6 @@ from .testassetsconstants import (
 from .testpublicassets import (
     TestPublicAssetsBase,
 )
-
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access

--- a/unittests/testpublicevents.py
+++ b/unittests/testpublicevents.py
@@ -4,7 +4,7 @@ Test public events
 
 from logging import getLogger
 from os import environ
-from unittest import mock, TestCase
+from unittest import TestCase, mock
 
 from archivist.archivistpublic import ArchivistPublic
 from archivist.constants import (
@@ -16,13 +16,13 @@ from archivist.constants import (
 )
 from archivist.logger import set_logger
 
+from .mock_response import MockResponse
+from .testevents import IDENTITY
 from .testeventsconstants import (
     ASSET_ATTRS,
     ASSET_ID,
     RESPONSE,
 )
-from .mock_response import MockResponse
-from .testevents import IDENTITY
 
 if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
     set_logger(environ["RKVST_LOGLEVEL"])

--- a/unittests/testpublicget.py
+++ b/unittests/testpublicget.py
@@ -14,7 +14,6 @@ from archivist.errors import (
 
 from .mock_response import MockResponse
 
-
 # pylint: disable=unused-variable
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
@@ -43,7 +42,7 @@ class TestPublicGet(TestPublicMethods):
         """
         with mock.patch.object(self.public.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200)
-            resp = self.public.get("https://path/path/entity/xxxxxxxx")
+            self.public.get("https://path/path/entity/xxxxxxxx")
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -63,7 +62,7 @@ class TestPublicGet(TestPublicMethods):
         """
         with mock.patch.object(self.public.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200)
-            resp = self.public.get("https://path/path/entity/xxxxxxxx")
+            self.public.get("https://path/path/entity/xxxxxxxx")
             last_response = self.public.last_response()
             self.assertEqual(last_response, [mock_get.return_value])
 
@@ -74,7 +73,7 @@ class TestPublicGet(TestPublicMethods):
         with mock.patch.object(self.public.session, "get") as mock_get:
             mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
             with self.assertRaises(ArchivistNotFoundError):
-                resp = self.public.get("https://path/path/entity/xxxxxxxx")
+                self.public.get("https://path/path/entity/xxxxxxxx")
 
     def test_get_with_headers(self):
         """
@@ -82,7 +81,7 @@ class TestPublicGet(TestPublicMethods):
         """
         with mock.patch.object(self.public.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200)
-            resp = self.public.get(
+            self.public.get(
                 "https://path/path/id/xxxxxxxx",
                 headers={"headerfield1": "headervalue1"},
             )
@@ -108,7 +107,7 @@ class TestPublicGet(TestPublicMethods):
         with mock.patch.object(self.public.session, "get") as mock_get:
             mock_get.return_value = MockResponse(429)
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.public.get(
+                self.public.get(
                     "https://path/path/id/xxxxxxxx",
                     headers={"headerfield1": "headervalue1"},
                 )
@@ -123,7 +122,7 @@ class TestPublicGet(TestPublicMethods):
                 MockResponse(429),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.public.get("https://path/path/entity/xxxxxxxx")
+                self.public.get("https://path/path/entity/xxxxxxxx")
 
     def test_get_with_429_retry_and_retries_fail(self):
         """
@@ -137,7 +136,7 @@ class TestPublicGet(TestPublicMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
             with self.assertRaises(ArchivistTooManyRequestsError):
-                resp = self.public.get("https://path/path/entity/xxxxxxxx")
+                self.public.get("https://path/path/entity/xxxxxxxx")
 
     def test_get_with_429_retry_and_success(self):
         """
@@ -149,7 +148,7 @@ class TestPublicGet(TestPublicMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
                 MockResponse(200),
             )
-            resp = self.public.get("https://path/path/entity/xxxxxxxx")
+            self.public.get("https://path/path/entity/xxxxxxxx")
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -197,7 +196,7 @@ class TestPublicGetFile(TestPublicMethods):
                 iter_content=iter_content(),
             )
             with BytesIO() as fd:
-                resp = self.public.get_file("https://path/path/entity/xxxxxxxx", fd)
+                self.public.get_file("https://path/path/entity/xxxxxxxx", fd)
                 self.assertEqual(
                     tuple(mock_get.call_args),
                     (
@@ -218,9 +217,8 @@ class TestPublicGetFile(TestPublicMethods):
         """
         with mock.patch.object(self.public.session, "get") as mock_get:
             mock_get.return_value = MockResponse(404, identity="entity/xxxxxxxx")
-            with self.assertRaises(ArchivistNotFoundError):
-                with BytesIO() as fd:
-                    resp = self.public.get_file("https://path/path/entity/xxxxxxxx", fd)
+            with self.assertRaises(ArchivistNotFoundError), BytesIO() as fd:
+                self.public.get_file("https://path/path/entity/xxxxxxxx", fd)
 
     def test_get_file_with_429(self):
         """
@@ -228,9 +226,8 @@ class TestPublicGetFile(TestPublicMethods):
         """
         with mock.patch.object(self.public.session, "get") as mock_get:
             mock_get.return_value = MockResponse(429)
-            with self.assertRaises(ArchivistTooManyRequestsError):
-                with BytesIO() as fd:
-                    resp = self.public.get_file("path/path/entity/xxxxxxxx", fd)
+            with self.assertRaises(ArchivistTooManyRequestsError), BytesIO() as fd:
+                self.public.get_file("path/path/entity/xxxxxxxx", fd)
 
     def test_get_file_with_429_retry_and_fail(self):
         """
@@ -241,9 +238,8 @@ class TestPublicGetFile(TestPublicMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
                 MockResponse(429),
             )
-            with self.assertRaises(ArchivistTooManyRequestsError):
-                with BytesIO() as fd:
-                    resp = self.public.get_file("path/path/entity/xxxxxxxx", fd)
+            with self.assertRaises(ArchivistTooManyRequestsError), BytesIO() as fd:
+                self.public.get_file("path/path/entity/xxxxxxxx", fd)
 
     def test_get_file_with_429_retry_and_retries_fail(self):
         """
@@ -256,9 +252,8 @@ class TestPublicGetFile(TestPublicMethods):
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
                 MockResponse(429, headers={HEADERS_RETRY_AFTER: 0.1}),
             )
-            with self.assertRaises(ArchivistTooManyRequestsError):
-                with BytesIO() as fd:
-                    resp = self.public.get_file("path/path/entity/xxxxxxxx", fd)
+            with self.assertRaises(ArchivistTooManyRequestsError), BytesIO() as fd:
+                self.public.get_file("path/path/entity/xxxxxxxx", fd)
 
     def test_get_file_with_429_retry_and_success(self):
         """
@@ -292,7 +287,7 @@ class TestPublicGetFile(TestPublicMethods):
                 ),
             )
             with BytesIO() as fd:
-                resp = self.public.get_file("path/path/entity/xxxxxxxx", fd)
+                self.public.get_file("path/path/entity/xxxxxxxx", fd)
                 self.assertEqual(
                     tuple(mock_get.call_args),
                     (

--- a/unittests/testrunner.py
+++ b/unittests/testrunner.py
@@ -6,11 +6,9 @@ from os import environ
 from unittest import TestCase
 
 # from archivist.errors import ArchivistBadRequestError
-
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
-
 from archivist.archivist import Archivist
 from archivist.assets import Asset
 from archivist.constants import ASSET_BEHAVIOURS

--- a/unittests/testrunneractiomap.py
+++ b/unittests/testrunneractiomap.py
@@ -5,15 +5,13 @@ from logging import getLogger
 from os import environ
 from unittest import TestCase
 
-from archivist.errors import ArchivistInvalidOperationError
-
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
-
 from archivist.archivist import Archivist
-from archivist.runner import _ActionMap
+from archivist.errors import ArchivistInvalidOperationError
 from archivist.logger import set_logger
+from archivist.runner import _ActionMap
 
 if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:
     set_logger(environ["RKVST_LOGLEVEL"])

--- a/unittests/testrunnerassets.py
+++ b/unittests/testrunnerassets.py
@@ -6,11 +6,9 @@ from os import environ
 from unittest import TestCase, mock
 
 # from archivist.errors import ArchivistBadRequestError
-
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
-
 from archivist.archivist import Archivist
 from archivist.assets import Asset
 from archivist.constants import ASSET_BEHAVIOURS

--- a/unittests/testrunnercompliance.py
+++ b/unittests/testrunnercompliance.py
@@ -6,11 +6,9 @@ from os import environ
 from unittest import TestCase, mock
 
 # from archivist.errors import ArchivistBadRequestError
-
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
-
 from archivist.archivist import Archivist
 from archivist.compliance import Compliance
 from archivist.compliance_policies import CompliancePolicy

--- a/unittests/testrunnerlocation.py
+++ b/unittests/testrunnerlocation.py
@@ -6,17 +6,14 @@ from os import environ
 from unittest import TestCase, mock
 
 # from archivist.errors import ArchivistBadRequestError
-
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
-
 from archivist.archivist import Archivist
-from archivist.locations import Location
 from archivist.constants import (
     LOCATIONS_LABEL,
 )
-
+from archivist.locations import Location
 from archivist.logger import set_logger
 
 if "RKVST_LOGLEVEL" in environ and environ["RKVST_LOGLEVEL"]:

--- a/unittests/testrunnerstep.py
+++ b/unittests/testrunnerstep.py
@@ -6,13 +6,12 @@ from os import environ
 from unittest import TestCase
 
 from archivist.archivist import Archivist
+from archivist.logger import set_logger
 
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 # pylint: disable=unused-variable
-
 from archivist.runner import _Step
-from archivist.logger import set_logger
 
 ASSET_ID = "assets/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
 LOCATION_ID = "locations/yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"

--- a/unittests/testsboms.py
+++ b/unittests/testsboms.py
@@ -9,10 +9,10 @@ from unittest import TestCase, mock
 from archivist.archivist import Archivist
 from archivist.constants import (
     ROOT,
-    SBOMS_SUBPATH,
     SBOMS_LABEL,
     SBOMS_METADATA,
     SBOMS_PUBLISH,
+    SBOMS_SUBPATH,
     SBOMS_WILDCARD,
     SBOMS_WITHDRAW,
 )
@@ -327,7 +327,7 @@ class TestSBOMSUploadDownload(TestSBOMSBase):
                 ArchivistNotFoundError("sbom not found"),
             ]
             with self.assertRaises(ArchivistNotFoundError):
-                sbom = self.arch.sboms.upload(self.mockstream, confirm=True)
+                self.arch.sboms.upload(self.mockstream, confirm=True)
 
     def test_sboms_download(self):
         """
@@ -389,7 +389,7 @@ class TestSBOMSUploadDownload(TestSBOMSBase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200, **RESPONSE)
 
-            sbom = self.arch.sboms.read(IDENTITY)
+            self.arch.sboms.read(IDENTITY)
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -412,7 +412,7 @@ class TestSBOMSUploadDownload(TestSBOMSBase):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
-            sbom = self.arch.sboms.publish(IDENTITY, confirm=False)
+            self.arch.sboms.publish(IDENTITY, confirm=False)
             self.assertEqual(
                 tuple(mock_post.call_args),
                 (
@@ -446,7 +446,7 @@ class TestSBOMSUploadDownload(TestSBOMSBase):
                 MockResponse(200, **RESPONSE),
             ]
             with self.assertRaises(ArchivistUnpublishedError):
-                sbom = self.arch.sboms.publish(IDENTITY, confirm=True)
+                self.arch.sboms.publish(IDENTITY, confirm=True)
 
     def test_sbom_withdraw(self):
         """
@@ -455,7 +455,7 @@ class TestSBOMSUploadDownload(TestSBOMSBase):
         with mock.patch.object(self.arch.session, "post") as mock_post:
             mock_post.return_value = MockResponse(200, **RESPONSE)
 
-            sbom = self.arch.sboms.withdraw(IDENTITY, confirm=False)
+            self.arch.sboms.withdraw(IDENTITY, confirm=False)
             self.assertEqual(
                 tuple(mock_post.call_args),
                 (
@@ -489,7 +489,7 @@ class TestSBOMSUploadDownload(TestSBOMSBase):
                 MockResponse(200, **RESPONSE),
             ]
             with self.assertRaises(ArchivistUnwithdrawnError):
-                sbom = self.arch.sboms.withdraw(IDENTITY, confirm=True)
+                self.arch.sboms.withdraw(IDENTITY, confirm=True)
 
     def test_sboms_list(self):
         """

--- a/unittests/testsubjects.py
+++ b/unittests/testsubjects.py
@@ -7,11 +7,11 @@ from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.constants import (
-    ROOT,
     HEADERS_REQUEST_TOTAL_COUNT,
     HEADERS_TOTAL_COUNT,
-    SUBJECTS_SUBPATH,
+    ROOT,
     SUBJECTS_LABEL,
+    SUBJECTS_SUBPATH,
 )
 from archivist.errors import ArchivistBadRequestError, ArchivistUnconfirmedError
 from archivist.logger import set_logger
@@ -315,7 +315,7 @@ class TestSubjects(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(200, **RESPONSE)
 
-            subject = self.arch.subjects.read(IDENTITY)
+            self.arch.subjects.read(IDENTITY)
             self.assertEqual(
                 tuple(mock_get.call_args),
                 (
@@ -338,7 +338,7 @@ class TestSubjects(TestCase):
         with mock.patch.object(self.arch.session, "delete") as mock_delete:
             mock_delete.return_value = MockResponse(200, {})
 
-            subject = self.arch.subjects.delete(IDENTITY)
+            self.arch.subjects.delete(IDENTITY)
             self.assertEqual(
                 tuple(mock_delete.call_args),
                 (
@@ -360,7 +360,7 @@ class TestSubjects(TestCase):
         with mock.patch.object(self.arch.session, "patch") as mock_patch:
             mock_patch.return_value = MockResponse(200, **RESPONSE)
 
-            subject = self.arch.subjects.update(
+            self.arch.subjects.update(
                 IDENTITY,
                 display_name=DISPLAY_NAME,
             )
@@ -389,7 +389,7 @@ class TestSubjects(TestCase):
         with mock.patch.object(self.arch.session, "get") as mock_get:
             mock_get.return_value = MockResponse(400)
             with self.assertRaises(ArchivistBadRequestError):
-                resp = self.arch.subjects.read(IDENTITY)
+                self.arch.subjects.read(IDENTITY)
 
     def test_subjects_count(self):
         """
@@ -439,7 +439,7 @@ class TestSubjects(TestCase):
                 ],
             )
 
-            count = self.arch.subjects.count(
+            self.arch.subjects.count(
                 display_name="Subject display name",
             )
             self.assertEqual(

--- a/unittests/testtenancies.py
+++ b/unittests/testtenancies.py
@@ -4,7 +4,7 @@ Test tenancies read
 
 from logging import getLogger
 from os import environ
-from unittest import mock, TestCase
+from unittest import TestCase, mock
 
 from archivist.archivist import Archivist
 from archivist.constants import (


### PR DESCRIPTION
Problem:
Slow linters are used that have complicated configuration and expensive to maintain.

Solution:
Introduce the new ruff linter which is super fast as it is written in Rust. Also has options to emit suggested solutions and also to automatically fix errors. This is just the introduction - eventually this will be added to a commit hook and the github actions and other linters will be removed.