### PR TITLE
Notebook test fails in pipeline

### DIFF
--- a/functests/execnotebooks.py
+++ b/functests/execnotebooks.py
@@ -2,6 +2,7 @@
 Test subjects
 """
 from os import getenv
+from unittest import skip
 
 from testbook import testbook
 
@@ -248,6 +249,7 @@ RKVST_URL {self.url}""",
             self.check_notebook_cell(notebook, 7)
             LOGGER.debug("=================================")
 
+    @skip("Requires root access credentials - see #7742")
     def test_share_artist_asset_user(self):
         """
         Test share_artist_asset_user


### PR DESCRIPTION
Problem:
The notebook functest for notebook 'Sharing Artist Asset with User' fails in pipeline because a root access token is required.

Solution:
Added skip clause to suppress the test.

Fixes [AB#7742](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/7742)