### PR TITLE
Resolve incompatible dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,9 @@
 
 # code quality
 autopep8~=2.0
-black[jupyter]~=23.1
+black[jupyter]~=23.3
 coverage[toml]~=7.1
-pip-audit~=2.4
+pip-audit~=2.5
 pycodestyle~=2.10
 pylint~=2.17
 pyright~=1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,15 @@ backoff~=1.11
 certifi
 flatten-dict~=0.4
 iso8601~=1.1
-Jinja2~=3.0
-pyaml-env~=1.1
-requests~=2.28
+Jinja2~=3.1
+pyaml-env~=1.2
+
+# TODO: these 2 dependencies are interdependent. Underlying changes to the
+#       urllib3 packages require they must both be upgraded to 2.30 and 1.0.0
+#       respectively. This cannot be done just yet as other pacakages (such
+#       as pip-audit) will break until all other python packages have also
+#       moved to the new requests. For now we pin to 2.29...
+requests~=2.29.0
 requests-toolbelt~=0.10
 rfc3339~=6.2
 xmltodict~=0.13


### PR DESCRIPTION
Resolve incompatible dependencies

Problem:
Requests and requests-toolbelt had incompatible dependencies 2.30 and
0.10.1 when removing appengine support.

Solution:
Degrade requests to version 2.29.
Upgrade to latest request is deferred until all other packages
are also upgraded.
