### PR TITLE
Pip audit shows warning.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,7 +38,6 @@ jobs:
         sudo rm -rf /var/lib/apt/lists/*
         python3 -m pip install --upgrade pip
         python3 -m pip install -r requirements-dev.txt
-        python3 -m pip install setuptools wheel
     - name: Run integrity checks
       run: |
         ./scripts/version.sh
@@ -55,7 +54,7 @@ jobs:
             exit 1
         fi
         ./scripts/unittests.sh
-    - uses: pypa/gh-action-pip-audit@v1.0.0
+    - uses: pypa/gh-action-pip-audit@v1.0.8
       with:
         inputs: requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,14 +9,8 @@ flatten-dict~=0.4
 iso8601~=1.1
 Jinja2~=3.1
 pyaml-env~=1.2
-
-# TODO: these 2 dependencies are interdependent. Underlying changes to the
-#       urllib3 packages require they must both be upgraded to 2.30 and 1.0.0
-#       respectively. This cannot be done just yet as other pacakages (such
-#       as pip-audit) will break until all other python packages have also
-#       moved to the new requests. For now we pin to 2.29...
-requests~=2.29.0
-requests-toolbelt~=0.10
+requests~=2.31.0
+requests-toolbelt~=1.0
 rfc3339~=6.2
 xmltodict~=0.13
 


### PR DESCRIPTION
Problem:
Pip audit reports vulnerability in underlying requests package.

Solution:
Upgrade pip audit version in github action and requirements-dev.txt.
Upgrade requests and requests-toolbelt in requirements.txt.
