### PR TITLE
Fix circular imports

### DIFF
--- a/archivist/access_policies.py
+++ b/archivist/access_policies.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, Generator, Optional
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 
 if TYPE_CHECKING:
-    from . import archivist
+    from .archivist import Archivist
 
 from .assets import Asset
 from .constants import (
@@ -63,7 +63,7 @@ class _AccessPoliciesClient:
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._subpath = f"{archivist_instance.root}/{ACCESS_POLICIES_SUBPATH}"
         self._label = f"{self._subpath}/{ACCESS_POLICIES_LABEL}"

--- a/archivist/appidp.py
+++ b/archivist/appidp.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 if TYPE_CHECKING:
-    from . import archivist
+    from .archivist import Archivist
 
 from .constants import (
     APPIDP_LABEL,
@@ -57,7 +57,7 @@ class _AppIDPClient:
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._subpath = f"{archivist_instance.root}/{APPIDP_SUBPATH}"
         self._label = f"{self._subpath}/{APPIDP_LABEL}"

--- a/archivist/applications.py
+++ b/archivist/applications.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
 if TYPE_CHECKING:
-    from . import archivist
+    from .archivist import Archivist
 
 from .constants import (
     APPLICATIONS_LABEL,
@@ -55,7 +55,7 @@ class _ApplicationsClient:
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._subpath = f"{archivist_instance.root}/{APPLICATIONS_SUBPATH}"
         self._label = f"{self._subpath}/{APPLICATIONS_LABEL}"

--- a/archivist/assetattachments.py
+++ b/archivist/assetattachments.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from requests.models import Response
 
     # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-    from . import archivist
+    from .archivist import Archivist
 
 from .constants import (
     ASSETATTACHMENTS_LABEL,
@@ -59,7 +59,7 @@ class _AssetAttachmentsClient:
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._public = archivist_instance.public
         self._subpath = f"{archivist_instance.root}/{ASSETATTACHMENTS_SUBPATH}"

--- a/archivist/assets.py
+++ b/archivist/assets.py
@@ -25,10 +25,10 @@ from __future__ import annotations
 
 from copy import deepcopy
 from logging import getLogger
-from typing import Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist, confirmer
+from . import confirmer
 from .asset import Asset
 from .constants import (
     ASSET_BEHAVIOURS,
@@ -39,6 +39,9 @@ from .constants import (
 from .dictmerge import _deepmerge
 from .errors import ArchivistBadFieldError, ArchivistNotFoundError
 from .utils import selector_signature
+
+if TYPE_CHECKING:
+    from .archivist import Archivist
 
 LOGGER = getLogger(__name__)
 
@@ -54,7 +57,7 @@ class _AssetsPublic:
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._public = archivist_instance.public
         self._subpath = f"{archivist_instance.root}/{ASSETS_SUBPATH}"
@@ -97,7 +100,7 @@ class _AssetsRestricted(_AssetsPublic):
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         super().__init__(archivist_instance)
         self._label = f"{self._subpath}/{ASSETS_LABEL}"
         self.pending_count: int = 0

--- a/archivist/attachments.py
+++ b/archivist/attachments.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from requests.models import Response
 
     # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-    from . import archivist
+    from .archivist import Archivist
 
 from .constants import (
     ATTACHMENTS_LABEL,
@@ -67,7 +67,7 @@ class _AttachmentsClient:
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._subpath = f"{archivist_instance.root}/{ATTACHMENTS_SUBPATH}"
         self._label = f"{self._subpath}/{ATTACHMENTS_LABEL}"

--- a/archivist/cmds/runner/run.py
+++ b/archivist/cmds/runner/run.py
@@ -5,16 +5,21 @@ from __future__ import annotations
 from logging import getLogger
 from os import environ
 from sys import exit as sys_exit
+from typing import TYPE_CHECKING
 
 from pyaml_env import parse_config
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from ... import about, archivist
+from ... import about
+
+if TYPE_CHECKING:
+    from ..archivist import Archivist
+
 
 LOGGER = getLogger(__name__)
 
 
-def run(arch: archivist.Archivist, args):
+def run(arch: Archivist, args):
     LOGGER.info("Using version %s of rkvst-archivist", about.__version__)
     LOGGER.info("Namespace %s", args.namespace)
 

--- a/archivist/compliance.py
+++ b/archivist/compliance.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-    from . import archivist
+    from .archivist import Archivist
 
 from .constants import (
     COMPLIANCE_LABEL,
@@ -58,7 +58,7 @@ class _ComplianceClient:  # pylint: disable=too-few-public-methods
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._subpath = f"{archivist_instance.root}/{COMPLIANCE_SUBPATH}"
         self._label = f"{self._subpath}/{COMPLIANCE_LABEL}"

--- a/archivist/compliance_policies.py
+++ b/archivist/compliance_policies.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
     # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-    from . import archivist
+    from .archivist import Archivist
     from .compliance_policy_requests import (
         CompliancePolicyCurrentOutstanding,
         CompliancePolicyDynamicTolerance,
@@ -75,7 +75,7 @@ class _CompliancePoliciesClient:
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._subpath = f"{archivist_instance.root}/{COMPLIANCE_POLICIES_SUBPATH}"
         self._label = f"{self._subpath}/{COMPLIANCE_POLICIES_LABEL}"

--- a/archivist/composite.py
+++ b/archivist/composite.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-    from . import archivist
+    from .archivist import Archivist
 
 
 LOGGER = getLogger(__name__)
@@ -46,7 +46,7 @@ class _CompositeClient:
     These mthods are not unittested and provided as a convenience.
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
 
     def __str__(self) -> str:

--- a/archivist/events.py
+++ b/archivist/events.py
@@ -26,10 +26,10 @@ from __future__ import annotations
 
 from copy import deepcopy
 from logging import getLogger
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist, confirmer
+from . import confirmer
 from .constants import (
     ASSETS_SUBPATH,
     ASSETS_WILDCARD,
@@ -40,6 +40,9 @@ from .constants import (
 from .dictmerge import _deepmerge
 from .errors import ArchivistBadFieldError, ArchivistNotFoundError
 from .sboms import sboms_parse
+
+if TYPE_CHECKING:
+    from .archivist import Archivist
 
 LOGGER = getLogger(__name__)
 
@@ -110,7 +113,7 @@ class _EventsPublic:
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._public = archivist_instance.public
         self._subpath = f"{archivist_instance.root}/{ASSETS_SUBPATH}"
@@ -282,7 +285,7 @@ class _EventsRestricted(_EventsPublic):
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         super().__init__(archivist_instance)
         self.pending_count: int = 0
 

--- a/archivist/locations.py
+++ b/archivist/locations.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 if TYPE_CHECKING:
     # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-    from . import archivist
+    from .archivist import Archivist
 
 from .constants import LOCATIONS_LABEL, LOCATIONS_SUBPATH
 from .dictmerge import _deepmerge
@@ -69,7 +69,7 @@ class _LocationsClient:
 
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._subpath = f"{archivist_instance.root}/{LOCATIONS_SUBPATH}"
         self._label = f"{self._subpath}/{LOCATIONS_LABEL}"

--- a/archivist/runner.py
+++ b/archivist/runner.py
@@ -20,7 +20,7 @@ from .errors import ArchivistError, ArchivistInvalidOperationError
 # pylint:disable=missing-function-docstring
 # pylint:disable=protected-access
 if TYPE_CHECKING:
-    from . import archivist
+    from .archivist import Archivist
 
 LOGGER = getLogger(__name__)
 
@@ -50,7 +50,7 @@ class _ActionMap(dict):
     #                                    a dictionary
     # similarly for location and subjects labels
     #
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         super().__init__()
         self._archivist = archivist_instance
 
@@ -228,7 +228,7 @@ class _ActionMap(dict):
 
 
 class _Step(dict):  # pylint:disable=too-many-instance-attributes
-    def __init__(self, archivist_instance: archivist.Archivist, **kwargs):
+    def __init__(self, archivist_instance: Archivist, **kwargs):
         super().__init__(**kwargs)
         self._archivist = archivist_instance
         self._args: list[Any] = []
@@ -397,7 +397,7 @@ class _Runner:
     ArchivistRunner takes a url, token_file.
     """
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self.entities: defaultdict
         self.deletions = {}

--- a/archivist/subjects.py
+++ b/archivist/subjects.py
@@ -26,16 +26,19 @@ from __future__ import annotations
 from base64 import b64decode
 from json import loads as json_loads
 from logging import getLogger
-from typing import Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-from . import archivist, subjects_confirmer
+from . import subjects_confirmer
 from .constants import (
     SUBJECTS_LABEL,
     SUBJECTS_SELF_ID,
     SUBJECTS_SUBPATH,
 )
 from .dictmerge import _deepmerge
+
+if TYPE_CHECKING:
+    from .archivist import Archivist
 
 LOGGER = getLogger(__name__)
 
@@ -57,7 +60,7 @@ class _SubjectsClient:
 
     maxDiff = None
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._subpath = f"{archivist_instance.root}/{SUBJECTS_SUBPATH}"
         self._label = f"{self._subpath}/{SUBJECTS_LABEL}"
@@ -91,7 +94,7 @@ class _SubjectsClient:
         )
 
     def share(
-        self, name: str, other_name: str, other_archivist: archivist.Archivist
+        self, name: str, other_name: str, other_archivist: Archivist
     ) -> Tuple[Subject, Subject]:
         """Import the self subjects from the foreign archivist connection
            from another organization - mutually share.

--- a/archivist/tenancies.py
+++ b/archivist/tenancies.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # pylint:disable=cyclic-import      # but pylint doesn't understand this feature
-    from . import archivist
+    from .archivist import Archivist
 
 from .constants import (
     TENANCIES_LABEL,
@@ -56,7 +56,7 @@ class _TenanciesClient:
 
     maxDiff = None
 
-    def __init__(self, archivist_instance: archivist.Archivist):
+    def __init__(self, archivist_instance: Archivist):
         self._archivist = archivist_instance
         self._subpath = f"{archivist_instance.root}/{TENANCIES_SUBPATH}"
         self._label = f"{self._subpath}/{TENANCIES_LABEL}"


### PR DESCRIPTION
The type-checking hints introduced circular imports. Changed the import to minimise imported symbols and only imported Archivist when type-checking was true.

Fixes [AB#8292](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/8292)
