### PR TITLE
Use nodejs debian package only

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -13,8 +13,6 @@ RUN curl -fsSOL https://taskfile.dev/install.sh \
   && sh install.sh \
   && rm -f install.sh
 
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-
 RUN apt-get update \
   && apt-get upgrade -y --no-install-recommends \
   && apt-get install -y --fix-missing \


### PR DESCRIPTION
See https://github.com/nodesource/distributions#new-update-%EF%B8%8F

The nodejs installation script is no longer supported.
