### PR TITLE
Support for python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11" ]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12" ]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -47,7 +47,6 @@ jobs:
         ./scripts/version.sh
         pycodestyle --format=pylint archivist examples functests unittests
         python3 -m pylint archivist examples functests unittests
-        python3 -m pyright --stats archivist
         black archivist examples unittests functests
         modified=$(git status -s | wc -l)
         if [ $modified -gt 0 ]
@@ -56,6 +55,12 @@ jobs:
             exit 1
         fi
         ./scripts/unittests.sh
+      shell: bash
+    - name: Run type-hint checks
+      if: ${{ matrix.python-version != '3.12' }}
+      run: |
+        ./scripts/version.sh
+        python3 -m pyright --stats archivist
       shell: bash
     - name: Run zip notebooks
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -251,6 +251,23 @@ To run the unittests:
 task unittests
 ```
 
+##### Python 3.12
+
+To build the docker builder image with Python 3.12:
+```bash
+task builder-3.12
+```
+
+To check the style
+```bash
+task check
+```
+
+To run the unittests:
+```bash
+task unittests
+```
+
 ### Seeking a review
 
 #### Synchronizing the upstream

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ documented at https://docs.rkvst.com
 Support
 =======
 
-This package currently is tested against Python versions 3.8,3.9,3.10 and 3.11.
+This package currently is tested against Python versions 3.8,3.9,3.10,3.11 and 3.12.
 
 The current default version is 3.8 - this means that this package will not
 use any features specific to versions 3.9 and later.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,9 @@
 version: '3'
 
+vars:
+  PYVERSION:
+    sh: echo $(./scripts/builder.sh python3 --version | cut -d' ' -f2| cut -d'.' -f1-2)
+
 tasks:
 
   about:
@@ -34,15 +38,28 @@ tasks:
     cmds:
       - ./scripts/build.sh "3.11"
 
+  builder-3.12:
+    desc: Build a docker environment with the right dependencies and utilities
+    cmds:
+      - ./scripts/build.sh "3.12"
+
   check:
     desc: Check the style, bug and quality of the code
     deps: [about]
     cmds:
-      - ./scripts/builder.sh python3 --version
+      - echo {{.PYVERSION}}
       - ./scripts/builder.sh ruff check archivist examples functests unittests
-      - ./scripts/builder.sh python3 -m pyright --stats archivist
       - ./scripts/builder.sh pycodestyle --format=pylint archivist examples functests unittests
       - ./scripts/builder.sh python3 -m pylint archivist examples functests unittests
+      - task: check-pyright
+
+  check-pyright:
+    desc: Execute pyright conditinally - currently does not work in 3.12 (https://github.com/ekalinin/nodeenv/issues/341)
+    cmds:
+      - |
+        if [ "{{.PYVERSION}}" != "3.12" ]; then
+            ./scripts/builder.sh python3 -m pyright --stats archivist
+        fi
 
   check-fixes:
     desc: Show proposed fixes from ruff

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -10,7 +10,7 @@ The definitive guide to the REST API is defined here: https://docs.rkvst.com
 This python SDK offers a number of advantages over a simple 
 REST api (in any language):
 
-    *  versioned package for the python 3.8,3.9,3.10,3.11 ecosystem.
+    *  versioned package for the python 3.8,3.9,3.10,3.11,3.12 ecosystem.
     *  automatic confirmation of assets and events: just set **confirm=True** when
        creating the asset or event and a sophisticated retry and exponential backoff
        algorithm will take care of everything.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,11 @@
 #
 # this is used for pushing to github pages
 #
-sphinx~=6.2
-sphinx-rtd-theme~=1.2
+# sphinx 7.2 does not support 3.8
+sphinx~=7.1
+sphinx-rtd-theme~=1.3
 sphinxcontrib-spelling~=8.0
-sphinx-gallery~=0.13
+sphinx-gallery~=0.14
 nbsphinx~=0.9
 
 -r notebooks/requirements.txt

--- a/docs/sbom.xml
+++ b/docs/sbom.xml
@@ -1,11 +1,11 @@
-<ns0:bom xmlns:ns0="http://cyclonedx.org/schema/bom/1.4" serialNumber="urn:uuid:8a3539e7-6e24-4059-88ac-a2b4315e20e5" version="1">
+<ns0:bom xmlns:ns0="http://cyclonedx.org/schema/bom/1.4" serialNumber="urn:uuid:3a0579f0-4046-4e0c-93b8-cc43418374c8" version="1">
   <ns0:metadata>
-    <ns0:timestamp>2023-07-19T10:28:54.412300+00:00</ns0:timestamp>
+    <ns0:timestamp>2023-10-18T08:27:07.469453+00:00</ns0:timestamp>
     <ns0:tools>
       <ns0:tool>
         <ns0:vendor>CycloneDX</ns0:vendor>
         <ns0:name>cyclonedx-python-lib</ns0:name>
-        <ns0:version>4.0.1</ns0:version>
+        <ns0:version>4.2.3</ns0:version>
         <ns0:externalReferences>
           <ns0:reference type="build-system">
             <ns0:url>https://github.com/CycloneDX/cyclonedx-python-lib/actions</ns0:url>
@@ -36,87 +36,87 @@
     </ns0:tools>
   </ns0:metadata>
   <ns0:components>
-    <ns0:component type="library" bom-ref="5cc798ec-3fb8-4c63-b632-94fc44919175">
+    <ns0:component type="library" bom-ref="cff268ae-0c68-4962-999e-70ad1da21803">
       <ns0:name>Jinja2</ns0:name>
       <ns0:version>3.1.2</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="c56dedc5-2f96-4160-9467-26cf24fcea6e">
+    <ns0:component type="library" bom-ref="26c8d8fd-a259-4b45-9195-10bf1f93cb9c">
       <ns0:name>MarkupSafe</ns0:name>
       <ns0:version>2.1.3</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="2f9cbf12-1f7f-4ac7-8d1d-aa40c4395134">
+    <ns0:component type="library" bom-ref="79370d31-3070-4629-9d8f-e53a07385200">
       <ns0:name>PyYAML</ns0:name>
       <ns0:version>6.0.1</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="ab0fcd29-bb81-4bba-8807-0d79177e0ec2">
+    <ns0:component type="library" bom-ref="55fb7a39-9381-478b-aab0-dbcb48a85ec4">
       <ns0:name>backoff</ns0:name>
-      <ns0:version>1.11.1</ns0:version>
+      <ns0:version>2.2.1</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="725c6de3-8f5e-496a-8ad8-ea10d0854c56">
+    <ns0:component type="library" bom-ref="1ba4da71-c87f-4b55-bdb3-eefd2e600e84">
       <ns0:name>certifi</ns0:name>
-      <ns0:version>2023.5.7</ns0:version>
+      <ns0:version>2023.7.22</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="bd400ba6-9fcf-4832-899a-895339b7558b">
+    <ns0:component type="library" bom-ref="306aba9f-bf80-4df0-87f2-e60b6afcbb01">
       <ns0:name>charset-normalizer</ns0:name>
-      <ns0:version>3.2.0</ns0:version>
+      <ns0:version>3.3.0</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="5e6b4bd9-bb68-4ab3-86da-60666bb8a724">
+    <ns0:component type="library" bom-ref="8d97e2e2-060a-4386-9e41-eb9c213acac3">
       <ns0:name>flatten-dict</ns0:name>
       <ns0:version>0.4.2</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="91ceaeff-04b6-4a0b-b956-dde96de6a7e3">
+    <ns0:component type="library" bom-ref="d9096dbe-837d-4834-bb8e-880cf78b18e3">
       <ns0:name>idna</ns0:name>
       <ns0:version>3.4</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="7ebb0e1b-f6e0-4e0b-801c-fc82013dbd44">
+    <ns0:component type="library" bom-ref="2b459c33-c5b6-4f05-94ce-1e8820a3a268">
       <ns0:name>iso8601</ns0:name>
-      <ns0:version>2.0.0</ns0:version>
+      <ns0:version>2.1.0</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="7c12c8b1-3148-41cf-a48c-6318f0cb0897">
+    <ns0:component type="library" bom-ref="f875da11-4af0-4efb-9e4b-273ab197875b">
       <ns0:name>pyaml-env</ns0:name>
       <ns0:version>1.2.1</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="47bbb034-87ec-4ab2-9af1-f84ebb8d2292">
+    <ns0:component type="library" bom-ref="0450554a-63e3-442d-bde1-318d79dc110a">
       <ns0:name>requests</ns0:name>
       <ns0:version>2.31.0</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="270f0753-b62e-4c87-9f8c-d7dfaf38dead">
+    <ns0:component type="library" bom-ref="7957cfe8-9c59-47db-ae86-eee234413123">
       <ns0:name>requests-toolbelt</ns0:name>
       <ns0:version>1.0.0</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="c6109be3-5df5-41a7-99ab-c65953477bb0">
+    <ns0:component type="library" bom-ref="793d7bb0-6377-42db-932d-1d95ff0523e3">
       <ns0:name>rfc3339</ns0:name>
       <ns0:version>6.2</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="8d6ba9d4-4a2f-49f1-bae1-33a970ebef7b">
+    <ns0:component type="library" bom-ref="63d2ee34-a196-4e05-859f-8a68e07f1b6c">
       <ns0:name>six</ns0:name>
       <ns0:version>1.16.0</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="3e857991-f43d-4e0b-beec-4785d2c52134">
+    <ns0:component type="library" bom-ref="821e7105-fa28-40e3-81b5-3e1b855d0873">
       <ns0:name>urllib3</ns0:name>
-      <ns0:version>2.0.3</ns0:version>
+      <ns0:version>2.0.7</ns0:version>
     </ns0:component>
-    <ns0:component type="library" bom-ref="1c21d7d0-7eb2-474a-93c1-5216bfec5f5f">
+    <ns0:component type="library" bom-ref="d884b97f-3b8e-4e7b-9378-24fa9885a3b1">
       <ns0:name>xmltodict</ns0:name>
       <ns0:version>0.13.0</ns0:version>
     </ns0:component>
   </ns0:components>
   <ns0:dependencies>
-    <ns0:dependency ref="1c21d7d0-7eb2-474a-93c1-5216bfec5f5f"/>
-    <ns0:dependency ref="270f0753-b62e-4c87-9f8c-d7dfaf38dead"/>
-    <ns0:dependency ref="2f9cbf12-1f7f-4ac7-8d1d-aa40c4395134"/>
-    <ns0:dependency ref="3e857991-f43d-4e0b-beec-4785d2c52134"/>
-    <ns0:dependency ref="47bbb034-87ec-4ab2-9af1-f84ebb8d2292"/>
-    <ns0:dependency ref="5cc798ec-3fb8-4c63-b632-94fc44919175"/>
-    <ns0:dependency ref="5e6b4bd9-bb68-4ab3-86da-60666bb8a724"/>
-    <ns0:dependency ref="725c6de3-8f5e-496a-8ad8-ea10d0854c56"/>
-    <ns0:dependency ref="7c12c8b1-3148-41cf-a48c-6318f0cb0897"/>
-    <ns0:dependency ref="7ebb0e1b-f6e0-4e0b-801c-fc82013dbd44"/>
-    <ns0:dependency ref="8d6ba9d4-4a2f-49f1-bae1-33a970ebef7b"/>
-    <ns0:dependency ref="91ceaeff-04b6-4a0b-b956-dde96de6a7e3"/>
-    <ns0:dependency ref="ab0fcd29-bb81-4bba-8807-0d79177e0ec2"/>
-    <ns0:dependency ref="bd400ba6-9fcf-4832-899a-895339b7558b"/>
-    <ns0:dependency ref="c56dedc5-2f96-4160-9467-26cf24fcea6e"/>
-    <ns0:dependency ref="c6109be3-5df5-41a7-99ab-c65953477bb0"/>
+    <ns0:dependency ref="0450554a-63e3-442d-bde1-318d79dc110a"/>
+    <ns0:dependency ref="1ba4da71-c87f-4b55-bdb3-eefd2e600e84"/>
+    <ns0:dependency ref="26c8d8fd-a259-4b45-9195-10bf1f93cb9c"/>
+    <ns0:dependency ref="2b459c33-c5b6-4f05-94ce-1e8820a3a268"/>
+    <ns0:dependency ref="306aba9f-bf80-4df0-87f2-e60b6afcbb01"/>
+    <ns0:dependency ref="55fb7a39-9381-478b-aab0-dbcb48a85ec4"/>
+    <ns0:dependency ref="63d2ee34-a196-4e05-859f-8a68e07f1b6c"/>
+    <ns0:dependency ref="79370d31-3070-4629-9d8f-e53a07385200"/>
+    <ns0:dependency ref="793d7bb0-6377-42db-932d-1d95ff0523e3"/>
+    <ns0:dependency ref="7957cfe8-9c59-47db-ae86-eee234413123"/>
+    <ns0:dependency ref="821e7105-fa28-40e3-81b5-3e1b855d0873"/>
+    <ns0:dependency ref="8d97e2e2-060a-4386-9e41-eb9c213acac3"/>
+    <ns0:dependency ref="cff268ae-0c68-4962-999e-70ad1da21803"/>
+    <ns0:dependency ref="d884b97f-3b8e-4e7b-9378-24fa9885a3b1"/>
+    <ns0:dependency ref="d9096dbe-837d-4834-bb8e-880cf78b18e3"/>
+    <ns0:dependency ref="f875da11-4af0-4efb-9e4b-273ab197875b"/>
   </ns0:dependencies>
 </ns0:bom>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,21 +2,21 @@
 
 # code quality
 autopep8~=2.0
-black[jupyter]~=23.7
-coverage[toml]~=7.2
+black[jupyter]~=23.9
+coverage[toml]~=7.3
 pip-audit~=2.6
 pycodestyle~=2.10
-pylint~=2.17
+pylint~=3.0
 pyright~=1.1
-ruff~=0.0
+ruff~=0.1
 unittest-xml-reporting~=3.2
 testbook~=0.4
 
 # analyze dependencies
-pipdeptree~=2.10
+pipdeptree~=2.13
 
 # uploading to pypi
-build~=0.10
+build~=1.0
 twine~=4.0
 
 # for sbom.xml file


### PR DESCRIPTION
Upgrade all dependencies that support python 3.8-3.12. Disable pyright for 3.12 as it is currently incompatible. (https://github.com/ekalinin/nodeenv/issues/341)

[AB#8633](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/8633)
